### PR TITLE
Mini-project #1: Orientation, done right

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 .DS_Store
 *.log
+.superpowers/

--- a/App/Alignment/AlignmentEngine.swift
+++ b/App/Alignment/AlignmentEngine.swift
@@ -55,7 +55,7 @@ public final class AlignmentEngine {
     // Stub implementation: returns moving image unmodified and identity transform
     public func align(moving: UIImage, reference: UIImage, options: AlignmentOptions = .init()) -> AlignmentResult {
         if options.useAppleVision {
-            if let res = VisionAligner.shared.align(moving: moving, reference: reference, targetMP: options.downscaleTargetMP, preferHomography: options.preferHomography) {
+            if let res = VisionAligner.shared.align(moving: moving, reference: reference, targetMP: options.downscaleTargetMP, preferHomography: options.preferHomography, enableFacePrealign: options.enableVisionPrealign) {
                 return AlignmentResult(alignedImage: res.alignedImage, transformModel: res.transformModel, metrics: res.metrics)
             }
         }

--- a/App/Alignment/AlignmentEngine.swift
+++ b/App/Alignment/AlignmentEngine.swift
@@ -8,6 +8,7 @@ public struct AlignmentOptions {
     public var enableLocalRefine: Bool = false
     public var downscaleTargetMP: Double = 1.5 // ~1–2MP
     public var timeBudgetMS: Int = 80 // preview budget
+    public var useAppleVision: Bool = true // prefer Vision when available
     public init() {}
 }
 
@@ -40,6 +41,11 @@ public final class AlignmentEngine {
 
     // Stub implementation: returns moving image unmodified and identity transform
     public func align(moving: UIImage, reference: UIImage, options: AlignmentOptions = .init()) -> AlignmentResult {
+        if options.useAppleVision {
+            if let res = VisionAligner.shared.align(moving: moving, reference: reference, targetMP: options.downscaleTargetMP, preferHomography: options.preferHomography) {
+                return AlignmentResult(alignedImage: res.alignedImage, transformModel: res.transformModel, metrics: res.metrics)
+            }
+        }
         let metrics = AlignmentMetrics(runtimeMS: 0, keypointsRef: 0, keypointsMov: 0, matches: 0, inliers: 0, inlierRatio: 0)
         return AlignmentResult(alignedImage: moving, transformModel: .identity, metrics: metrics)
     }
@@ -47,6 +53,14 @@ public final class AlignmentEngine {
     // Preview fast-path: render at preview size; default stub just aspect-fill scales
     public func previewAlignForOverlay(moving: UIImage, referencePreviewSize: CGSize, options: AlignmentOptions = .init()) -> UIImage {
         guard referencePreviewSize.width > 0, referencePreviewSize.height > 0 else { return moving }
+        if options.useAppleVision {
+            // Create a fake reference canvas at the preview size to drive warping
+            let reference = blankImage(size: referencePreviewSize, scale: UIScreen.main.scale)
+            if let res = VisionAligner.shared.align(moving: moving, reference: reference, targetMP: 1.0, preferHomography: options.preferHomography) {
+                return res.alignedImage
+            }
+        }
+        // Fallback: just aspect-fill to preview size
         let target = referencePreviewSize
         let format = UIGraphicsImageRendererFormat()
         format.scale = UIScreen.main.scale
@@ -62,6 +76,17 @@ public final class AlignmentEngine {
             moving.draw(in: CGRect(x: x, y: y, width: w, height: h))
         }
     }
+
+    private func blankImage(size: CGSize, scale: CGFloat) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = scale
+        format.opaque = true
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { ctx in
+            UIColor.black.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+    }
 }
 
 // MARK: - Notes
@@ -69,4 +94,3 @@ public final class AlignmentEngine {
 // will be provided by an Objective-C++ wrapper over OpenCV (OCVAligner), and optionally
 // Apple Vision for semantic pre-alignment. Until OpenCV is added to the project and the
 // wrapper is wired into the build, these methods act as no-ops so the app compiles.
-

--- a/App/Alignment/AlignmentEngine.swift
+++ b/App/Alignment/AlignmentEngine.swift
@@ -1,0 +1,72 @@
+import UIKit
+
+// MARK: - Models
+
+public struct AlignmentOptions {
+    public var preferHomography: Bool = true
+    public var enableVisionPrealign: Bool = true
+    public var enableLocalRefine: Bool = false
+    public var downscaleTargetMP: Double = 1.5 // ~1–2MP
+    public var timeBudgetMS: Int = 80 // preview budget
+    public init() {}
+}
+
+public enum TransformModel {
+    case identity
+    case homography(matrix3x3: [Double], inliers: Int, inlierRatio: Double)
+    case affine(matrix2x3: [Double], inliers: Int, inlierRatio: Double)
+}
+
+public struct AlignmentMetrics {
+    public var runtimeMS: Int
+    public var keypointsRef: Int
+    public var keypointsMov: Int
+    public var matches: Int
+    public var inliers: Int
+    public var inlierRatio: Double
+}
+
+public struct AlignmentResult {
+    public var alignedImage: UIImage
+    public var transformModel: TransformModel
+    public var metrics: AlignmentMetrics
+}
+
+// MARK: - Engine
+
+public final class AlignmentEngine {
+    public static let shared = AlignmentEngine()
+    private init() {}
+
+    // Stub implementation: returns moving image unmodified and identity transform
+    public func align(moving: UIImage, reference: UIImage, options: AlignmentOptions = .init()) -> AlignmentResult {
+        let metrics = AlignmentMetrics(runtimeMS: 0, keypointsRef: 0, keypointsMov: 0, matches: 0, inliers: 0, inlierRatio: 0)
+        return AlignmentResult(alignedImage: moving, transformModel: .identity, metrics: metrics)
+    }
+
+    // Preview fast-path: render at preview size; default stub just aspect-fill scales
+    public func previewAlignForOverlay(moving: UIImage, referencePreviewSize: CGSize, options: AlignmentOptions = .init()) -> UIImage {
+        guard referencePreviewSize.width > 0, referencePreviewSize.height > 0 else { return moving }
+        let target = referencePreviewSize
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: target, format: format)
+        return renderer.image { ctx in
+            let imgSize = moving.size
+            let scale = max(target.width / imgSize.width, target.height / imgSize.height)
+            let w = imgSize.width * scale
+            let h = imgSize.height * scale
+            let x = (target.width - w) / 2
+            let y = (target.height - h) / 2
+            moving.draw(in: CGRect(x: x, y: y, width: w, height: h))
+        }
+    }
+}
+
+// MARK: - Notes
+// This file defines the public Swift API for image alignment. The actual implementation
+// will be provided by an Objective-C++ wrapper over OpenCV (OCVAligner), and optionally
+// Apple Vision for semantic pre-alignment. Until OpenCV is added to the project and the
+// wrapper is wired into the build, these methods act as no-ops so the app compiles.
+

--- a/App/Alignment/AlignmentEngine.swift
+++ b/App/Alignment/AlignmentEngine.swift
@@ -10,6 +10,19 @@ public struct AlignmentOptions {
     public var timeBudgetMS: Int = 80 // preview budget
     public var useAppleVision: Bool = true // prefer Vision when available
     public init() {}
+    public init(preferHomography: Bool,
+                enableVisionPrealign: Bool,
+                enableLocalRefine: Bool,
+                downscaleTargetMP: Double,
+                timeBudgetMS: Int,
+                useAppleVision: Bool) {
+        self.preferHomography = preferHomography
+        self.enableVisionPrealign = enableVisionPrealign
+        self.enableLocalRefine = enableLocalRefine
+        self.downscaleTargetMP = downscaleTargetMP
+        self.timeBudgetMS = timeBudgetMS
+        self.useAppleVision = useAppleVision
+    }
 }
 
 public enum TransformModel {

--- a/App/Alignment/OCVAligner.h
+++ b/App/Alignment/OCVAligner.h
@@ -1,0 +1,33 @@
+// Placeholder Objective-C++ wrapper header for OpenCV alignment.
+// Not wired into the build yet. Implementation to follow when OpenCV is added.
+
+#import <Foundation/Foundation.h>
+#import <CoreGraphics/CoreGraphics.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSInteger, OCVTransformKind) {
+    OCVTransformKindIdentity = 0,
+    OCVTransformKindHomography,
+    OCVTransformKindAffinePartial,
+};
+
+@interface OCVAlignmentResult : NSObject
+@property(nonatomic, strong) UIImage *alignedImage;
+@property(nonatomic, assign) OCVTransformKind kind;
+@property(nonatomic, strong) NSArray<NSNumber *> *matrix; // 3x3 (9) for H or 2x3 (6) for affine
+@property(nonatomic, assign) NSInteger inliers;
+@property(nonatomic, assign) double inlierRatio;
+@property(nonatomic, assign) NSInteger runtimeMS;
+@end
+
+@interface OCVAligner : NSObject
+- (instancetype)init;
+- (OCVAlignmentResult *)alignMoving:(UIImage *)moving
+                          reference:(UIImage *)reference
+                           options:(NSDictionary *)options; // keys TBD
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/App/Alignment/OCVAligner.mm
+++ b/App/Alignment/OCVAligner.mm
@@ -1,0 +1,25 @@
+// Placeholder Objective-C++ wrapper implementation (no OpenCV calls yet).
+// Add OpenCV includes and real implementation in a follow-up step.
+
+#import "OCVAligner.h"
+
+@implementation OCVAlignmentResult
+@end
+
+@implementation OCVAligner
+
+- (instancetype)init { self = [super init]; return self; }
+
+- (OCVAlignmentResult *)alignMoving:(UIImage *)moving reference:(UIImage *)reference options:(NSDictionary *)options {
+    OCVAlignmentResult *res = [OCVAlignmentResult new];
+    res.alignedImage = moving; // no-op for now
+    res.kind = OCVTransformKindIdentity;
+    res.matrix = @[@1,@0,@0, @0,@1,@0, @0,@0,@1];
+    res.inliers = 0;
+    res.inlierRatio = 0.0;
+    res.runtimeMS = 0;
+    return res;
+}
+
+@end
+

--- a/App/Alignment/VisionAlignment.swift
+++ b/App/Alignment/VisionAlignment.swift
@@ -82,20 +82,24 @@ final class VisionAligner {
     }
 
     private func applyHomography(observation: VNImageHomographicAlignmentObservation, moving: UIImage, referenceSize: CGSize, scale: CGFloat) -> UIImage? {
-        // Convert 3x3 to map the four corners of the moving image to destination points, scaled to full-res
+        // Vision uses a bottom-left origin coordinate system. Core Image also uses a bottom-left origin.
+        // Define corners in bottom-left space and pass transformed corners directly to CIPerspectiveTransform.
         let Hs = observation.warpTransform
         let H = scaleHomography(Hs, by: scale)
-        let corners = [CGPoint(x: 0, y: 0), CGPoint(x: moving.size.width, y: 0), CGPoint(x: moving.size.width, y: moving.size.height), CGPoint(x: 0, y: moving.size.height)]
-        let dst = corners.map { applyHomographyPoint(H, $0) }
+        let w = moving.size.width
+        let h = moving.size.height
+        // Bottom-left coords: TL:(0,h) TR:(w,h) BR:(w,0) BL:(0,0)
+        let cornersBL = [CGPoint(x: 0, y: h), CGPoint(x: w, y: h), CGPoint(x: w, y: 0), CGPoint(x: 0, y: 0)]
+        let dstBL = cornersBL.map { applyHomographyPoint(H, $0) }
 
         guard let ci = CIImage(image: moving) else { return nil }
         let filter = CIFilter(name: "CIPerspectiveTransform")!
         filter.setValue(ci, forKey: kCIInputImageKey)
-        // Core Image expects dest corners in order: topLeft, topRight, bottomRight, bottomLeft
-        filter.setValue(CIVector(cgPoint: dst[0]), forKey: "inputTopLeft")
-        filter.setValue(CIVector(cgPoint: dst[1]), forKey: "inputTopRight")
-        filter.setValue(CIVector(cgPoint: dst[2]), forKey: "inputBottomRight")
-        filter.setValue(CIVector(cgPoint: dst[3]), forKey: "inputBottomLeft")
+        // Input expects: topLeft, topRight, bottomRight, bottomLeft — which correspond to our BL-space ordering.
+        filter.setValue(CIVector(cgPoint: dstBL[0]), forKey: "inputTopLeft")
+        filter.setValue(CIVector(cgPoint: dstBL[1]), forKey: "inputTopRight")
+        filter.setValue(CIVector(cgPoint: dstBL[2]), forKey: "inputBottomRight")
+        filter.setValue(CIVector(cgPoint: dstBL[3]), forKey: "inputBottomLeft")
 
         guard let out = filter.outputImage else { return nil }
         let rect = CGRect(origin: .zero, size: referenceSize)

--- a/App/Alignment/VisionAlignment.swift
+++ b/App/Alignment/VisionAlignment.swift
@@ -60,19 +60,24 @@ final class VisionAligner {
     // MARK: - Apply Transforms
 
     private func applyAffine(observation: VNImageTranslationAlignmentObservation, moving: UIImage, referenceSize: CGSize, scale: CGFloat) -> UIImage? {
-        // VN returns transform mapping moving->reference on scaled images.
-        // Scale translation to full-res.
+        // VN transforms are in a bottom-left origin coordinate system. Convert the CGContext
+        // to match Vision/CI coordinates by flipping Y, then apply the transform directly.
         let tScaled = observation.alignmentTransform
-        var t = CGAffineTransform(a: tScaled.a, b: tScaled.b, c: tScaled.c, d: tScaled.d, tx: tScaled.tx * scale, ty: tScaled.ty * scale)
+        let t = CGAffineTransform(a: tScaled.a, b: tScaled.b, c: tScaled.c, d: tScaled.d, tx: tScaled.tx * scale, ty: tScaled.ty * scale)
 
         let format = UIGraphicsImageRendererFormat()
         format.scale = moving.scale
         format.opaque = false
         let renderer = UIGraphicsImageRenderer(size: referenceSize, format: format)
         return renderer.image { ctx in
-            ctx.cgContext.clear(CGRect(origin: .zero, size: referenceSize))
-            ctx.cgContext.concatenate(t)
-            moving.draw(in: CGRect(origin: .zero, size: moving.size))
+            let cg = ctx.cgContext
+            cg.clear(CGRect(origin: .zero, size: referenceSize))
+            // Flip to bottom-left coordinate space
+            cg.translateBy(x: 0, y: referenceSize.height)
+            cg.scaleBy(x: 1, y: -1)
+            // Apply Vision transform and draw
+            cg.concatenate(t)
+            cg.draw(moving.cgImage!, in: CGRect(origin: .zero, size: moving.size))
         }
     }
 
@@ -153,4 +158,3 @@ final class VisionAligner {
         return CGPoint(x: CGFloat(r.x / w), y: CGFloat(r.y / w))
     }
 }
-

--- a/App/Alignment/VisionAlignment.swift
+++ b/App/Alignment/VisionAlignment.swift
@@ -1,0 +1,156 @@
+import UIKit
+import Vision
+import CoreImage
+
+struct VisionAlignmentResult {
+    let alignedImage: UIImage
+    let transformModel: TransformModel
+    let metrics: AlignmentMetrics
+}
+
+final class VisionAligner {
+    static let shared = VisionAligner()
+    private let ciContext = CIContext()
+    private init() {}
+
+    func align(moving: UIImage, reference: UIImage, targetMP: Double = 1.5, preferHomography: Bool = true) -> VisionAlignmentResult? {
+        let start = CFAbsoluteTimeGetCurrent()
+
+        // Normalize orientations and compute shared downscale
+        guard let refUp = movingToUp(reference), let movUp = movingToUp(moving) else { return nil }
+        let (refScaled, movScaled, scale) = downscalePair(reference: refUp, moving: movUp, targetMP: targetMP)
+
+        // Try translational first for speed, then homography if requested
+        if let obs = runTranslational(moving: movScaled, reference: refScaled), let aligned = applyAffine(observation: obs, moving: movUp, referenceSize: refUp.size, scale: scale) {
+            let dt = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+            let metrics = AlignmentMetrics(runtimeMS: dt, keypointsRef: 0, keypointsMov: 0, matches: 0, inliers: 0, inlierRatio: 0)
+            return VisionAlignmentResult(alignedImage: aligned, transformModel: .affine(matrix2x3: transformArray(from: obs.alignmentTransform, scale: 1.0), inliers: 0, inlierRatio: 0), metrics: metrics)
+        }
+
+        guard preferHomography else { return nil }
+
+        if let obs = runHomography(moving: movScaled, reference: refScaled), let aligned = applyHomography(observation: obs, moving: movUp, referenceSize: refUp.size, scale: scale) {
+            let dt = Int(((CFAbsoluteTimeGetCurrent() - start) * 1000).rounded())
+            let m = matrixArray(from: obs.warpTransform)
+            let metrics = AlignmentMetrics(runtimeMS: dt, keypointsRef: 0, keypointsMov: 0, matches: 0, inliers: 0, inlierRatio: 0)
+            return VisionAlignmentResult(alignedImage: aligned, transformModel: .homography(matrix3x3: m, inliers: 0, inlierRatio: 0), metrics: metrics)
+        }
+
+        return nil
+    }
+
+    // MARK: - Vision Requests
+
+    private func runTranslational(moving: UIImage, reference: UIImage) -> VNImageTranslationAlignmentObservation? {
+        guard let refCG = reference.cgImage, let movCG = moving.cgImage else { return nil }
+        let req = VNTranslationalImageRegistrationRequest(targetedCGImage: movCG, options: [:])
+        let handler = VNImageRequestHandler(cgImage: refCG, options: [:])
+        try? handler.perform([req])
+        return req.results?.first as? VNImageTranslationAlignmentObservation
+    }
+
+    private func runHomography(moving: UIImage, reference: UIImage) -> VNImageHomographicAlignmentObservation? {
+        guard let refCG = reference.cgImage, let movCG = moving.cgImage else { return nil }
+        let req = VNHomographicImageRegistrationRequest(targetedCGImage: movCG, options: [:])
+        let handler = VNImageRequestHandler(cgImage: refCG, options: [:])
+        try? handler.perform([req])
+        return req.results?.first as? VNImageHomographicAlignmentObservation
+    }
+
+    // MARK: - Apply Transforms
+
+    private func applyAffine(observation: VNImageTranslationAlignmentObservation, moving: UIImage, referenceSize: CGSize, scale: CGFloat) -> UIImage? {
+        // VN returns transform mapping moving->reference on scaled images.
+        // Scale translation to full-res.
+        let tScaled = observation.alignmentTransform
+        var t = CGAffineTransform(a: tScaled.a, b: tScaled.b, c: tScaled.c, d: tScaled.d, tx: tScaled.tx * scale, ty: tScaled.ty * scale)
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = moving.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: referenceSize, format: format)
+        return renderer.image { ctx in
+            ctx.cgContext.clear(CGRect(origin: .zero, size: referenceSize))
+            ctx.cgContext.concatenate(t)
+            moving.draw(in: CGRect(origin: .zero, size: moving.size))
+        }
+    }
+
+    private func applyHomography(observation: VNImageHomographicAlignmentObservation, moving: UIImage, referenceSize: CGSize, scale: CGFloat) -> UIImage? {
+        // Convert 3x3 to map the four corners of the moving image to destination points, scaled to full-res
+        let Hs = observation.warpTransform
+        let H = scaleHomography(Hs, by: scale)
+        let corners = [CGPoint(x: 0, y: 0), CGPoint(x: moving.size.width, y: 0), CGPoint(x: moving.size.width, y: moving.size.height), CGPoint(x: 0, y: moving.size.height)]
+        let dst = corners.map { applyHomographyPoint(H, $0) }
+
+        guard let ci = CIImage(image: moving) else { return nil }
+        let filter = CIFilter(name: "CIPerspectiveTransform")!
+        filter.setValue(ci, forKey: kCIInputImageKey)
+        // Core Image expects dest corners in order: topLeft, topRight, bottomRight, bottomLeft
+        filter.setValue(CIVector(cgPoint: dst[0]), forKey: "inputTopLeft")
+        filter.setValue(CIVector(cgPoint: dst[1]), forKey: "inputTopRight")
+        filter.setValue(CIVector(cgPoint: dst[2]), forKey: "inputBottomRight")
+        filter.setValue(CIVector(cgPoint: dst[3]), forKey: "inputBottomLeft")
+
+        guard let out = filter.outputImage else { return nil }
+        let rect = CGRect(origin: .zero, size: referenceSize)
+        guard let cg = ciContext.createCGImage(out, from: rect) else { return nil }
+        return UIImage(cgImage: cg, scale: moving.scale, orientation: .up)
+    }
+
+    // MARK: - Helpers
+
+    private func movingToUp(_ image: UIImage) -> UIImage? {
+        guard image.imageOrientation != .up else { return image }
+        let size = image.size
+        UIGraphicsBeginImageContextWithOptions(size, false, image.scale)
+        image.draw(in: CGRect(origin: .zero, size: size))
+        let result = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+        return result
+    }
+
+    private func downscalePair(reference: UIImage, moving: UIImage, targetMP: Double) -> (UIImage, UIImage, CGFloat) {
+        func downscale(_ img: UIImage) -> (UIImage, CGFloat) {
+            let mp = (img.size.width * img.size.height) / 1_000_000.0
+            if mp <= targetMP { return (img, 1.0) }
+            let scale = sqrt(CGFloat(mp / targetMP))
+            let newSize = CGSize(width: img.size.width / scale, height: img.size.height / scale)
+            UIGraphicsBeginImageContextWithOptions(newSize, false, 1.0)
+            img.draw(in: CGRect(origin: .zero, size: newSize))
+            let reduced = UIGraphicsGetImageFromCurrentImageContext() ?? img
+            UIGraphicsEndImageContext()
+            return (reduced, scale)
+        }
+        let (refScaled, refScale) = downscale(reference)
+        let (movScaled, movScale) = downscale(moving)
+        // Use average scale if different to reduce mismatch; we will scale transforms by this factor.
+        let scale = max(refScale, movScale)
+        return (refScaled, movScaled, scale)
+    }
+
+    private func transformArray(from t: CGAffineTransform, scale: CGFloat) -> [Double] {
+        return [Double(t.a), Double(t.b), 0.0, Double(t.c), Double(t.d), 0.0, Double(t.tx * scale), Double(t.ty * scale), 1.0]
+    }
+
+    private func matrixArray(from m: simd_float3x3) -> [Double] {
+        return [Double(m.columns.0.x), Double(m.columns.0.y), Double(m.columns.0.z),
+                Double(m.columns.1.x), Double(m.columns.1.y), Double(m.columns.1.z),
+                Double(m.columns.2.x), Double(m.columns.2.y), Double(m.columns.2.z)]
+    }
+
+    private func scaleHomography(_ m: simd_float3x3, by s: CGFloat) -> simd_float3x3 {
+        // H_full = D * H_scaled * D^-1, with D = diag(s, s, 1)
+        let D = simd_float3x3([SIMD3(Float(s), 0, 0), SIMD3(0, Float(s), 0), SIMD3(0, 0, 1)])
+        let Dinv = simd_float3x3([SIMD3(1/Float(s), 0, 0), SIMD3(0, 1/Float(s), 0), SIMD3(0, 0, 1)])
+        return D * m * Dinv
+    }
+
+    private func applyHomographyPoint(_ H: simd_float3x3, _ p: CGPoint) -> CGPoint {
+        let v = SIMD3(Float(p.x), Float(p.y), 1)
+        let r = H * v
+        let w = max(r.z, 1e-6)
+        return CGPoint(x: CGFloat(r.x / w), y: CGFloat(r.y / w))
+    }
+}
+

--- a/App/Alignment/VisionAlignment.swift
+++ b/App/Alignment/VisionAlignment.swift
@@ -13,12 +13,17 @@ final class VisionAligner {
     private let ciContext = CIContext()
     private init() {}
 
-    func align(moving: UIImage, reference: UIImage, targetMP: Double = 1.5, preferHomography: Bool = true) -> VisionAlignmentResult? {
+    func align(moving: UIImage, reference: UIImage, targetMP: Double = 1.5, preferHomography: Bool = true, enableFacePrealign: Bool = true) -> VisionAlignmentResult? {
         let start = CFAbsoluteTimeGetCurrent()
 
         // Normalize orientations and compute shared downscale
         guard let refUp = movingToUp(reference), let movUp = movingToUp(moving) else { return nil }
-        let (refScaled, movScaled, scale) = downscalePair(reference: refUp, moving: movUp, targetMP: targetMP)
+        var (refScaled, movScaled, scale) = downscalePair(reference: refUp, moving: movUp, targetMP: targetMP)
+
+        // Optional face-based similarity pre-align to improve portraits
+        if enableFacePrealign, let pre = similarityPrealign(moving: movScaled, reference: refScaled) {
+            movScaled = pre
+        }
 
         // Try translational first for speed, then homography if requested
         if let obs = runTranslational(moving: movScaled, reference: refScaled), let aligned = applyAffine(observation: obs, moving: movUp, referenceSize: refUp.size, scale: scale) {
@@ -160,5 +165,90 @@ final class VisionAligner {
         let r = H * v
         let w = max(r.z, 1e-6)
         return CGPoint(x: CGFloat(r.x / w), y: CGFloat(r.y / w))
+    }
+
+    // MARK: - Vision Face Similarity Prealign
+    private func similarityPrealign(moving: UIImage, reference: UIImage) -> UIImage? {
+        guard let movCG = moving.cgImage, let refCG = reference.cgImage else { return nil }
+        // Detect faces
+        let movObs = detectLargestFaceObservations(in: movCG)
+        let refObs = detectLargestFaceObservations(in: refCG)
+        guard let m = movObs, let r = refObs else { return nil }
+        // Extract anchors (eyes preferred; fallback to face center+width)
+        guard let mAnc = faceAnchorsTopLeft(from: m, imageSize: moving.size),
+              let rAnc = faceAnchorsTopLeft(from: r, imageSize: reference.size) else { return nil }
+
+        // Compute similarity mapping moving->reference around eye midpoints
+        let mMid = CGPoint(x: (mAnc.leftEye.x + mAnc.rightEye.x)/2, y: (mAnc.leftEye.y + mAnc.rightEye.y)/2)
+        let rMid = CGPoint(x: (rAnc.leftEye.x + rAnc.rightEye.x)/2, y: (rAnc.leftEye.y + rAnc.rightEye.y)/2)
+        let mVec = CGVector(dx: mAnc.rightEye.x - mAnc.leftEye.x, dy: mAnc.rightEye.y - mAnc.leftEye.y)
+        let rVec = CGVector(dx: rAnc.rightEye.x - rAnc.leftEye.x, dy: rAnc.rightEye.y - rAnc.leftEye.y)
+        let mLen = max(hypot(mVec.dx, mVec.dy), 1e-6)
+        let rLen = max(hypot(rVec.dx, rVec.dy), 1e-6)
+        let scale = rLen / mLen
+        let angle = atan2(rVec.dy, rVec.dx) - atan2(mVec.dy, mVec.dx)
+
+        var t = CGAffineTransform.identity
+        t = t.translatedBy(x: rMid.x, y: rMid.y)
+        t = t.rotated(by: angle)
+        t = t.scaledBy(x: scale, y: scale)
+        t = t.translatedBy(x: -mMid.x, y: -mMid.y)
+
+        // Render moving into reference-sized canvas using similarity transform
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = moving.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: reference.size, format: format)
+        let prewarped = renderer.image { ctx in
+            let cg = ctx.cgContext
+            // Core Graphics is top-left; our anchors are top-left already
+            cg.concatenate(t)
+            moving.draw(in: CGRect(origin: .zero, size: moving.size))
+        }
+        return prewarped
+    }
+
+    private func detectLargestFaceObservations(in cgImage: CGImage) -> VNFaceObservation? {
+        let req = VNDetectFaceLandmarksRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage, options: [:])
+        try? handler.perform([req])
+        guard let faces = req.results as? [VNFaceObservation], !faces.isEmpty else { return nil }
+        return faces.max(by: { $0.boundingBox.width * $0.boundingBox.height < $1.boundingBox.width * $1.boundingBox.height })
+    }
+
+    private struct FaceAnchors { let leftEye: CGPoint; let rightEye: CGPoint }
+
+    private func faceAnchorsTopLeft(from obs: VNFaceObservation, imageSize: CGSize) -> FaceAnchors? {
+        // Prefer eye landmarks; fallback to approximate using face box
+        func mapPoint(_ p: CGPoint, in bbox: CGRect) -> CGPoint {
+            // p is normalized in bbox (0..1). bbox is normalized in image, BL origin.
+            let xBL = bbox.origin.x + p.x * bbox.size.width
+            let yBL = bbox.origin.y + p.y * bbox.size.height
+            // Convert to top-left image coords
+            let x = xBL * imageSize.width
+            let y = (1.0 - yBL) * imageSize.height
+            return CGPoint(x: x, y: y)
+        }
+        if let lm = obs.landmarks,
+           let left = lm.leftEye?.normalizedPoints,
+           let right = lm.rightEye?.normalizedPoints,
+           !left.isEmpty, !right.isEmpty {
+            // Average landmark points for centers
+            let l = left.reduce(CGPoint.zero) { CGPoint(x: $0.x + CGFloat($1.x), y: $0.y + CGFloat($1.y)) }
+            let r = right.reduce(CGPoint.zero) { CGPoint(x: $0.x + CGFloat($1.x), y: $0.y + CGFloat($1.y)) }
+            let lAvg = CGPoint(x: l.x / CGFloat(left.count), y: l.y / CGFloat(left.count))
+            let rAvg = CGPoint(x: r.x / CGFloat(right.count), y: r.y / CGFloat(right.count))
+            let bbox = obs.boundingBox
+            return FaceAnchors(leftEye: mapPoint(lAvg, in: bbox), rightEye: mapPoint(rAvg, in: bbox))
+        }
+        // Fallback: approximate eyes horizontally across face center with width proportion
+        let bbox = obs.boundingBox
+        let centerBL = CGPoint(x: bbox.origin.x + bbox.size.width * 0.5, y: bbox.origin.y + bbox.size.height * 0.6)
+        let width = bbox.size.width * imageSize.width
+        let eyeOffset = width * 0.15
+        let centerTL = CGPoint(x: centerBL.x * imageSize.width, y: (1.0 - centerBL.y) * imageSize.height)
+        let left = CGPoint(x: centerTL.x - eyeOffset, y: centerTL.y)
+        let right = CGPoint(x: centerTL.x + eyeOffset, y: centerTL.y)
+        return FaceAnchors(leftEye: left, rightEye: right)
     }
 }

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -14,6 +14,14 @@ class CameraModel: ObservableObject {
     private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
     private var previewAngleObservation: NSKeyValueObservation?
     private var captureAngleObservation: NSKeyValueObservation?
+
+    // TEMP DEBUG: on-screen HUD to confirm running build and inspect orientation ground truth.
+    @Published var debugInfo: String = "O3 — waiting for camera"
+    private var lastPreviewAngle: CGFloat = -1
+    private var lastCaptureAngle: CGFloat = -1
+    private func refreshDebugInfo(extra: String = "") {
+        debugInfo = "O3 prev=\(Int(lastPreviewAngle)) cap=\(Int(lastCaptureAngle)) \(extra)"
+    }
     
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -96,14 +104,18 @@ class CameraModel: ObservableObject {
     }
 
     private func applyPreviewAngle(_ angle: CGFloat) {
+        lastPreviewAngle = angle
         guard let connection = previewView?.previewLayer.connection else { return }
         if connection.isVideoRotationAngleSupported(angle) {
             connection.videoRotationAngle = angle
         }
+        refreshDebugInfo()
     }
 
     private func applyCaptureAngle(_ angle: CGFloat) async {
+        lastCaptureAngle = angle
         await captureService.applyCaptureGeometry(rotationAngle: angle)
+        refreshDebugInfo()
     }
 
     func capturePhoto() {
@@ -111,6 +123,7 @@ class CameraModel: ObservableObject {
             do {
                 let (image, photo) = try await captureService.capturePhotoWithRawData()
                 print("📷 DEBUG: Captured raw image with size: \(image.size), orientation: \(image.imageOrientation.displayName)")
+                refreshDebugInfo(extra: "exif=\(photo.cgImageOrientation.rawValue) sz=\(Int(image.size.width))x\(Int(image.size.height))")
 
                 // Store raw image for final processing
                 capturedRawImages.append(image)

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -3,6 +3,7 @@ import AVFoundation
 import Photos
 import UIKit
 import CoreImage
+import Vision
 
 @MainActor
 class CameraModel: ObservableObject {
@@ -30,6 +31,10 @@ class CameraModel: ObservableObject {
             previewView?.setExposureAlpha(CGFloat(ghostExposureAlpha), currentImages: ghostPreviewImages)
         }
     }
+    
+    // Save-time alignment flag (Vision). When enabled, align subsequent images to the first capture
+    // using Apple Vision (translation → homography) before blending.
+    @Published var isAlignmentEnabled: Bool = true
     @Published var showAlert = false
     @Published var alertMessage = ""
     
@@ -153,8 +158,26 @@ class CameraModel: ObservableObject {
                         print("🖼️ DEBUG: Single image used as-is (no CGImage)")
                     }
                 } else {
-                    print("🖼️ DEBUG: Blending \(processedImages.count) processed images...")
-                    finalImage = blendImages(processedImages)
+                    var imagesForBlend = processedImages
+                    if isAlignmentEnabled {
+                        print("🧭 ALIGN: Aligning \(processedImages.count - 1) images to reference using Vision...")
+                        let reference = processedImages[0]
+                        var aligned: [UIImage] = [reference]
+                        for (idx, img) in processedImages.dropFirst().enumerated() {
+                            let options = AlignmentOptions(preferHomography: true,
+                                                           enableVisionPrealign: true,
+                                                           enableLocalRefine: false,
+                                                           downscaleTargetMP: 1.5,
+                                                           timeBudgetMS: 250,
+                                                           useAppleVision: true)
+                            let res = AlignmentEngine.shared.align(moving: img, reference: reference, options: options)
+                            aligned.append(res.alignedImage)
+                            print("🧭 ALIGN: #\(idx+2) model=\(res.transformModel) runtime=\(res.metrics.runtimeMS)ms")
+                        }
+                        imagesForBlend = aligned
+                    }
+                    print("🖼️ DEBUG: Blending \(imagesForBlend.count) images (aligned: \(isAlignmentEnabled))...")
+                    finalImage = blendImages(imagesForBlend)
                     print("🖼️ DEBUG: Blend complete")
                 }
                 

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -88,8 +88,8 @@ class CameraModel: ObservableObject {
                 // Rotate ghost to match camera preview orientation  
                 let rotatedGhost = rotateImageClockwise(image)
                 ghostPreviewImages.append(rotatedGhost)
-                // Update overlay within the preview layer to ensure perfect alignment
-                previewView?.updateGhostImages(ghostPreviewImages, opacity: CGFloat(1.0 - ghostOpacity))
+                // Update overlay (optionally with Vision alignment) for live preview
+                updateGhostPreviewOverlay()
                 print("📷 DEBUG: Ghost image size: \(rotatedGhost.size), scale: \(rotatedGhost.scale) (rotated to match preview)")
                 
                 print("📷 DEBUG: Total captured images: \(capturedRawImages.count) (raw + \(ghostPreviewImages.count) ghost previews)")
@@ -219,6 +219,58 @@ class CameraModel: ObservableObject {
         capturedPhotos.removeAll()
         ghostPreviewImages.removeAll()
         previewView?.updateGhostImages([], opacity: 0)
+    }
+
+    // MARK: - Live Ghost Preview Alignment
+    private func updateGhostPreviewOverlay() {
+        guard let canvasSize = previewView?.previewLayer.bounds.size, canvasSize.width > 0, canvasSize.height > 0 else {
+            // Fallback: draw originals
+            previewView?.updateGhostImages(ghostPreviewImages, opacity: CGFloat(1.0 - ghostOpacity))
+            return
+        }
+
+        // Scale all ghosts to preview canvas
+        let scaled = ghostPreviewImages.map { scaleImage($0, toAspectFill: canvasSize) }
+
+        guard isAlignmentEnabled else {
+            previewView?.updateGhostImages(scaled, opacity: CGFloat(1.0 - ghostOpacity))
+            return
+        }
+
+        guard let first = scaled.first else {
+            previewView?.updateGhostImages([], opacity: CGFloat(1.0 - ghostOpacity))
+            return
+        }
+
+        // Align subsequent images to the first using Vision at preview scale
+        var aligned: [UIImage] = [first]
+        for img in scaled.dropFirst() {
+            let opts = AlignmentOptions(preferHomography: true,
+                                        enableVisionPrealign: true,
+                                        enableLocalRefine: false,
+                                        downscaleTargetMP: 1.0,
+                                        timeBudgetMS: 80,
+                                        useAppleVision: true)
+            let res = AlignmentEngine.shared.align(moving: img, reference: first, options: opts)
+            aligned.append(res.alignedImage)
+        }
+        previewView?.updateGhostImages(aligned, opacity: CGFloat(1.0 - ghostOpacity))
+    }
+
+    private func scaleImage(_ image: UIImage, toAspectFill canvasSize: CGSize) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: canvasSize, format: format)
+        return renderer.image { ctx in
+            let imgSize = image.size
+            let s = max(canvasSize.width / imgSize.width, canvasSize.height / imgSize.height)
+            let w = imgSize.width * s
+            let h = imgSize.height * s
+            let x = (canvasSize.width - w) / 2
+            let y = (canvasSize.height - h) / 2
+            image.draw(in: CGRect(x: x, y: y, width: w, height: h))
+        }
     }
 
     private func makeThumbnail(from image: UIImage, maxSide: CGFloat) -> UIImage? {

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -242,17 +242,14 @@ class CameraModel: ObservableObject {
             return
         }
 
-        // Align subsequent images to the first using Vision at preview scale
+        // Align subsequent images to the first using Vision (translation only) at preview scale
         var aligned: [UIImage] = [first]
         for img in scaled.dropFirst() {
-            let opts = AlignmentOptions(preferHomography: true,
-                                        enableVisionPrealign: true,
-                                        enableLocalRefine: false,
-                                        downscaleTargetMP: 1.0,
-                                        timeBudgetMS: 80,
-                                        useAppleVision: true)
-            let res = AlignmentEngine.shared.align(moving: img, reference: first, options: opts)
-            aligned.append(res.alignedImage)
+            if let a = translationalAlignPreview(moving: img, reference: first) {
+                aligned.append(a)
+            } else {
+                aligned.append(img)
+            }
         }
         previewView?.updateGhostImages(aligned, opacity: CGFloat(1.0 - ghostOpacity))
     }
@@ -270,6 +267,28 @@ class CameraModel: ObservableObject {
             let x = (canvasSize.width - w) / 2
             let y = (canvasSize.height - h) / 2
             image.draw(in: CGRect(x: x, y: y, width: w, height: h))
+        }
+    }
+
+    // Use Vision translational registration for fast, robust preview alignment in top-left coords
+    private func translationalAlignPreview(moving: UIImage, reference: UIImage) -> UIImage? {
+        guard let refCG = reference.cgImage, let movCG = moving.cgImage else { return nil }
+        let req = VNTranslationalImageRegistrationRequest(targetedCGImage: movCG, options: [:])
+        let handler = VNImageRequestHandler(cgImage: refCG, options: [:])
+        do { try handler.perform([req]) } catch { return nil }
+        guard let obs = req.results?.first as? VNImageTranslationAlignmentObservation else { return nil }
+        let t = obs.alignmentTransform
+        // Convert Vision bottom-left translation to top-left: (tx, -ty)
+        let tx = t.tx
+        let ty = -t.ty
+        let size = reference.size
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = UIScreen.main.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+        return renderer.image { ctx in
+            // Draw moving shifted by (tx, ty) in top-left coordinates
+            moving.draw(in: CGRect(origin: CGPoint(x: tx, y: ty), size: moving.size))
         }
     }
 

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -14,14 +14,6 @@ class CameraModel: ObservableObject {
     private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
     private var previewAngleObservation: NSKeyValueObservation?
     private var captureAngleObservation: NSKeyValueObservation?
-
-    // TEMP DEBUG: on-screen HUD to confirm running build and inspect orientation ground truth.
-    @Published var debugInfo: String = "O4 — waiting for camera"
-    private var lastPreviewAngle: CGFloat = -1
-    private var lastCaptureAngle: CGFloat = -1
-    private func refreshDebugInfo(extra: String = "") {
-        debugInfo = "O4 prev=\(Int(lastPreviewAngle)) cap=\(Int(lastCaptureAngle)) \(extra)"
-    }
     
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -104,18 +96,14 @@ class CameraModel: ObservableObject {
     }
 
     private func applyPreviewAngle(_ angle: CGFloat) {
-        lastPreviewAngle = angle
         guard let connection = previewView?.previewLayer.connection else { return }
         if connection.isVideoRotationAngleSupported(angle) {
             connection.videoRotationAngle = angle
         }
-        refreshDebugInfo()
     }
 
     private func applyCaptureAngle(_ angle: CGFloat) async {
-        lastCaptureAngle = angle
         await captureService.applyCaptureGeometry(rotationAngle: angle)
-        refreshDebugInfo()
     }
 
     func capturePhoto() {
@@ -123,7 +111,6 @@ class CameraModel: ObservableObject {
             do {
                 let (image, photo) = try await captureService.capturePhotoWithRawData()
                 print("📷 DEBUG: Captured raw image with size: \(image.size), orientation: \(image.imageOrientation.displayName)")
-                refreshDebugInfo(extra: "exif=\(photo.cgImageOrientation.rawValue) sz=\(Int(image.size.width))x\(Int(image.size.height))")
 
                 // Store raw image for final processing
                 capturedRawImages.append(image)

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -178,8 +178,13 @@ class CameraModel: ObservableObject {
                         let reference = processedImages[0]
                         var aligned: [UIImage] = [reference]
                         for (idx, img) in processedImages.dropFirst().enumerated() {
+                            // Face pre-align is disabled: it warps only the downscaled image used
+                            // to compute the transform, but the final transform is applied to the
+                            // original image, causing front-camera (face) shots to shift sideways.
+                            // Translational alignment alone is what makes the back camera lock in.
+                            // A correct face-aware aligner is deferred to mini-project #4.
                             let options = AlignmentOptions(preferHomography: true,
-                                                           enableVisionPrealign: true,
+                                                           enableVisionPrealign: false,
                                                            enableLocalRefine: false,
                                                            downscaleTargetMP: 1.5,
                                                            timeBudgetMS: 250,

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -47,9 +47,6 @@ class CameraModel: ObservableObject {
     @Published var showSavedThumbnail: Bool = false
     private var recentSavedLocalIdentifier: String?
     
-    private var captureOrientation: UIDeviceOrientation = .portrait
-    private var captureCamera: AVCaptureDevice.Position = .back
-    
     var previewSource: PreviewSource {
         captureService
     }
@@ -112,29 +109,20 @@ class CameraModel: ObservableObject {
     func capturePhoto() {
         Task {
             do {
-                // Only capture orientation and camera position for the first image
-                if capturedRawImages.isEmpty {
-                    captureOrientation = UIDevice.current.orientation
-                    captureCamera = await captureService.currentCameraPosition
-                    print("📷 DEBUG: First capture - orientation: \(captureOrientation), camera: \(captureCamera)")
-                }
-                
                 let (image, photo) = try await captureService.capturePhotoWithRawData()
                 print("📷 DEBUG: Captured raw image with size: \(image.size), orientation: \(image.imageOrientation.displayName)")
-                
+
                 // Store raw image for final processing
                 capturedRawImages.append(image)
                 capturedPhotos.append(photo)
-                
-                // Rotate ghost to match camera preview orientation  
-                let rotatedGhost = rotateImageClockwise(image)
-                ghostPreviewImages.append(rotatedGhost)
+
+                // Frames are already upright (rotation handled at capture time).
+                ghostPreviewImages.append(image)
                 // Update overlay (optionally with Vision alignment) for live preview
                 updateGhostPreviewOverlay()
-                print("📷 DEBUG: Ghost image size: \(rotatedGhost.size), scale: \(rotatedGhost.scale) (rotated to match preview)")
-                
+
                 print("📷 DEBUG: Total captured images: \(capturedRawImages.count) (raw + \(ghostPreviewImages.count) ghost previews)")
-                
+
             } catch {
                 alertMessage = "Failed to capture photo: \(error.localizedDescription)"
                 showAlert = true
@@ -175,30 +163,14 @@ class CameraModel: ObservableObject {
                 print("🖼️ DEBUG: Starting save process with \(capturedRawImages.count) raw images")
                 print("🖼️ DEBUG: Raw image sizes: \(capturedRawImages.map { $0.size })")
                 
-                // Process raw images (apply rotation) at save time for speed
-                print("🖼️ DEBUG: Processing raw images with orientation/rotation...")
-                var processedImages: [UIImage] = []
-                
-                for (index, rawImage) in capturedRawImages.enumerated() {
-                    let shouldRotate = shouldRotateImage(rawImage, for: captureOrientation, cameraPosition: captureCamera)
-                    let processedImage = shouldRotate ? rotateImage(rawImage, for: captureOrientation, cameraPosition: captureCamera) : rawImage
-                    processedImages.append(processedImage)
-                    print("🖼️ DEBUG: Processed image \(index + 1), rotated: \(shouldRotate)")
-                }
-                
+                // Frames are captured upright; no rotation needed.
+                let processedImages = capturedRawImages
+
                 // Blend multiple images into one if we have more than one
                 let finalImage: UIImage
                 if processedImages.count == 1 {
-                    // Align behavior with multi-exposure path: apply the same 90° clockwise
-                    // correction so single-portrait captures are not saved rotated CCW.
-                    if let cg = processedImages[0].cgImage {
-                        let rotated = rotateCGImageClockwise(cg)
-                        finalImage = UIImage(cgImage: rotated, scale: processedImages[0].scale, orientation: .up)
-                        print("🖼️ DEBUG: Single image rotated 90° clockwise for consistent orientation")
-                    } else {
-                        finalImage = processedImages[0]
-                        print("🖼️ DEBUG: Single image used as-is (no CGImage)")
-                    }
+                    finalImage = processedImages[0]
+                    print("🖼️ DEBUG: Single upright image saved as-is")
                 } else {
                     var imagesForBlend = processedImages
                     if isAlignmentEnabled {
@@ -353,212 +325,24 @@ class CameraModel: ObservableObject {
     }
     
     private func blendImages(_ images: [UIImage]) -> UIImage {
-        print("🎨 DEBUG: Starting blend with \(images.count) images")
-        
-        guard let firstImage = images.first, images.count > 1 else {
-            print("🎨 DEBUG: Single image, no blending needed")
-            return images.first ?? UIImage()
-        }
-        
-        print("🎨 DEBUG: Blending multiple images using screen blend mode")
-        
-        // Use the first image as the base canvas
-        let canvasSize = firstImage.size
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
-        
-        guard let context = CGContext(data: nil,
-                                    width: Int(canvasSize.width),
-                                    height: Int(canvasSize.height),
-                                    bitsPerComponent: 8,
-                                    bytesPerRow: 0,
-                                    space: colorSpace,
-                                    bitmapInfo: bitmapInfo) else {
-            print("🎨 DEBUG: Failed to create CGContext")
-            return firstImage
-        }
-        
-        // Start with transparent background for ghostly layering
-        context.clear(CGRect(origin: .zero, size: canvasSize))
-        
+        guard let first = images.first else { return UIImage() }
+        guard images.count > 1 else { return first }
+
+        let canvasSize = first.size
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = first.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: canvasSize, format: format)
         let drawRect = CGRect(origin: .zero, size: canvasSize)
-        
-        // Option 1: Lighten blend mode - keeps saturation, creates ghostly overlaps
-        // This brightens where images overlap while preserving colors
-        for (index, image) in images.enumerated() {
-            guard let cgImage = image.cgImage else {
-                print("🎨 DEBUG: Failed to get CGImage from image \(index)")
-                continue
+
+        return renderer.image { ctx in
+            ctx.cgContext.clear(drawRect)
+            // Lighten blend with per-exposure alpha, matching the live preview compositor.
+            // UIImage.draw handles image orientation correctly (no manual rotation needed).
+            for image in images {
+                image.draw(in: drawRect, blendMode: .lighten, alpha: CGFloat(ghostExposureAlpha))
             }
-            
-            // Use lighten blend mode for ghostly effect with full saturation
-            context.setBlendMode(.lighten)
-            // Slight transparency per exposure; configurable to match preview
-            context.setAlpha(CGFloat(ghostExposureAlpha))
-            context.draw(cgImage, in: drawRect)
-            print("🎨 DEBUG: Drew image \(index + 1) with lighten blend mode, alpha: \(ghostExposureAlpha)")
         }
-        
-        guard let blendedCGImage = context.makeImage() else {
-            print("🎨 DEBUG: Failed to create final blended CGImage")
-            return firstImage
-        }
-        
-        // Apply 90° clockwise rotation to fix the counterclockwise rotation issue
-        let rotatedCGImage = rotateCGImageClockwise(blendedCGImage)
-        let blendedImage = UIImage(cgImage: rotatedCGImage, scale: firstImage.scale, orientation: .up)
-        print("🎨 DEBUG: Created blended image with \(images.count) exposures, applied 90° clockwise rotation")
-        return blendedImage
-    }
-    
-    private func rotateCGImageClockwise(_ cgImage: CGImage) -> CGImage {
-        let width = cgImage.width
-        let height = cgImage.height
-        
-        // Create rotated context (swap width/height for 90° rotation)
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
-        
-        guard let context = CGContext(data: nil,
-                                    width: height,  // swapped
-                                    height: width,  // swapped
-                                    bitsPerComponent: 8,
-                                    bytesPerRow: 0,
-                                    space: colorSpace,
-                                    bitmapInfo: bitmapInfo) else {
-            print("🎨 DEBUG: Failed to create rotation context")
-            return cgImage
-        }
-        
-        // Apply 90° counterclockwise rotation transform
-        context.translateBy(x: 0, y: CGFloat(width))
-        context.rotate(by: -.pi / 2)  // 90° counterclockwise
-        
-        // Draw the original image in the rotated context
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-        
-        guard let rotatedImage = context.makeImage() else {
-            print("🎨 DEBUG: Failed to create rotated image")
-            return cgImage
-        }
-        
-        print("🎨 DEBUG: Applied 90° clockwise rotation: \(width)x\(height) -> \(height)x\(width)")
-        return rotatedImage
-    }
-    
-    private func shouldRotateImage(_ image: UIImage, for orientation: UIDeviceOrientation, cameraPosition: AVCaptureDevice.Position) -> Bool {
-        print("📷 DEBUG: Checking rotation need - Device: \(orientation.rawValue), Image: \(image.imageOrientation.displayName)")
-        
-        // For portrait device orientation, camera typically provides .right orientation images
-        // In this case, we don't need to rotate since the image is already correct for display
-        if orientation == .portrait && image.imageOrientation == .right {
-            print("📷 DEBUG: Portrait device + Right image orientation = No rotation needed")
-            return false
-        }
-        
-        // If device is portrait and image is already .up, also no rotation needed
-        if orientation == .portrait && image.imageOrientation == .up {
-            print("📷 DEBUG: Portrait device + Up image orientation = No rotation needed") 
-            return false
-        }
-        
-        // For all other combinations, apply rotation
-        print("📷 DEBUG: Will apply rotation for device \(orientation.rawValue) + image \(image.imageOrientation.displayName)")
-        return true
-    }
-    
-    private func rotateImage(_ image: UIImage, for orientation: UIDeviceOrientation, cameraPosition: AVCaptureDevice.Position) -> UIImage {
-        
-        // Get the rotation angle based on device orientation and camera position
-        let rotationAngle: CGFloat
-        
-        switch orientation {
-        case .portrait:
-            rotationAngle = 0 // No rotation needed
-        case .portraitUpsideDown:
-            rotationAngle = .pi // 180 degrees
-        case .landscapeLeft:
-            // For front camera, swap left and right rotations due to mirror effect
-            if cameraPosition == .front {
-                rotationAngle = .pi / 2 // Use right rotation for left tilt
-            } else {
-                rotationAngle = -.pi / 2 // Standard left rotation for rear camera
-            }
-        case .landscapeRight:
-            // For front camera, swap left and right rotations due to mirror effect
-            if cameraPosition == .front {
-                rotationAngle = -.pi / 2 // Use left rotation for right tilt
-            } else {
-                rotationAngle = .pi / 2 // Standard right rotation for rear camera
-            }
-        default:
-            // For unknown, faceUp, faceDown orientations, don't rotate
-            rotationAngle = 0
-        }
-        
-        // If no rotation needed, return original image
-        guard rotationAngle != 0 else { return image }
-        
-        // Create a new image context with rotated image
-        let size = image.size
-        let rotatedSize: CGSize
-        
-        // For 90-degree rotations, swap width and height
-        if abs(rotationAngle) == .pi / 2 {
-            rotatedSize = CGSize(width: size.height, height: size.width)
-        } else {
-            rotatedSize = size
-        }
-        
-        UIGraphicsBeginImageContextWithOptions(rotatedSize, false, image.scale)
-        defer { UIGraphicsEndImageContext() }
-        
-        guard let context = UIGraphicsGetCurrentContext() else { return image }
-        
-        // Move to center of the new image
-        context.translateBy(x: rotatedSize.width / 2, y: rotatedSize.height / 2)
-        
-        // Rotate the context
-        context.rotate(by: rotationAngle)
-        
-        // Draw the image (centered on the rotated context)
-        image.draw(in: CGRect(x: -size.width / 2, y: -size.height / 2, width: size.width, height: size.height))
-        
-        return UIGraphicsGetImageFromCurrentImageContext() ?? image
-    }
-    
-    private func rotateImageClockwise(_ image: UIImage) -> UIImage {
-        guard let cgImage = image.cgImage else { return image }
-        
-        let width = cgImage.width
-        let height = cgImage.height
-        
-        // Create rotated context (swap width/height for 90° rotation)
-        let colorSpace = CGColorSpaceCreateDeviceRGB()
-        let bitmapInfo = CGImageAlphaInfo.premultipliedLast.rawValue
-        
-        guard let context = CGContext(data: nil,
-                                    width: height,  // swapped
-                                    height: width,  // swapped
-                                    bitsPerComponent: 8,
-                                    bytesPerRow: 0,
-                                    space: colorSpace,
-                                    bitmapInfo: bitmapInfo) else {
-            return image
-        }
-        
-        // Apply 90° counterclockwise rotation transform
-        context.translateBy(x: 0, y: CGFloat(width))
-        context.rotate(by: -.pi / 2)  // 90° counterclockwise
-        
-        // Draw the original image in the rotated context
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
-        
-        guard let rotatedCGImage = context.makeImage() else {
-            return image
-        }
-        
-        return UIImage(cgImage: rotatedCGImage, scale: image.scale, orientation: .up)
     }
 }
 

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -16,11 +16,11 @@ class CameraModel: ObservableObject {
     private var captureAngleObservation: NSKeyValueObservation?
 
     // TEMP DEBUG: on-screen HUD to confirm running build and inspect orientation ground truth.
-    @Published var debugInfo: String = "O3 — waiting for camera"
+    @Published var debugInfo: String = "O4 — waiting for camera"
     private var lastPreviewAngle: CGFloat = -1
     private var lastCaptureAngle: CGFloat = -1
     private func refreshDebugInfo(extra: String = "") {
-        debugInfo = "O3 prev=\(Int(lastPreviewAngle)) cap=\(Int(lastCaptureAngle)) \(extra)"
+        debugInfo = "O4 prev=\(Int(lastPreviewAngle)) cap=\(Int(lastCaptureAngle)) \(extra)"
     }
     
     @Published var isAuthorized = false

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -14,6 +14,11 @@ class CameraModel: ObservableObject {
     private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
     private var previewAngleObservation: NSKeyValueObservation?
     private var captureAngleObservation: NSKeyValueObservation?
+
+    /// Capture rotation angle locked to the first exposure of the current stack, so every
+    /// exposure shares one orientation (portrait or landscape) and blends cleanly. Nil when
+    /// no stack is in progress; reset on save/clear so the next stack picks a fresh orientation.
+    private var lockedCaptureAngle: CGFloat?
     
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -81,7 +86,8 @@ class CameraModel: ObservableObject {
         rotationCoordinator = coordinator
 
         applyPreviewAngle(coordinator.videoRotationAngleForHorizonLevelPreview)
-        await applyCaptureAngle(coordinator.videoRotationAngleForHorizonLevelCapture)
+        // If a stack is in progress, keep its locked orientation; otherwise track the device.
+        await applyCaptureAngle(lockedCaptureAngle ?? coordinator.videoRotationAngleForHorizonLevelCapture)
 
         previewAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelPreview,
                                                       options: [.new]) { [weak self] _, change in
@@ -91,7 +97,13 @@ class CameraModel: ObservableObject {
         captureAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelCapture,
                                                       options: [.new]) { [weak self] _, change in
             guard let angle = change.newValue else { return }
-            Task { @MainActor in await self?.applyCaptureAngle(angle) }
+            Task { @MainActor in
+                guard let self else { return }
+                // Don't let device rotation override a stack's locked orientation.
+                if self.lockedCaptureAngle == nil {
+                    await self.applyCaptureAngle(angle)
+                }
+            }
         }
     }
 
@@ -109,6 +121,15 @@ class CameraModel: ObservableObject {
     func capturePhoto() {
         Task {
             do {
+                // Lock the stack's orientation to the first exposure's physical orientation,
+                // then apply it for every shot so the whole stack stays portrait or landscape.
+                if capturedRawImages.isEmpty {
+                    lockedCaptureAngle = rotationCoordinator?.videoRotationAngleForHorizonLevelCapture
+                }
+                if let angle = lockedCaptureAngle {
+                    await applyCaptureAngle(angle)
+                }
+
                 let (image, photo) = try await captureService.capturePhotoWithRawData()
                 print("📷 DEBUG: Captured raw image with size: \(image.size), orientation: \(image.imageOrientation.displayName)")
 
@@ -225,6 +246,7 @@ class CameraModel: ObservableObject {
                 capturedRawImages.removeAll()
                 capturedPhotos.removeAll()
                 ghostPreviewImages.removeAll()
+                lockedCaptureAngle = nil  // next stack picks a fresh orientation
                 previewView?.updateGhostImages([], opacity: 0)
             } catch {
                 alertMessage = "Failed to save photo: \(error.localizedDescription)"
@@ -237,6 +259,7 @@ class CameraModel: ObservableObject {
         capturedRawImages.removeAll()
         capturedPhotos.removeAll()
         ghostPreviewImages.removeAll()
+        lockedCaptureAngle = nil  // next stack picks a fresh orientation
         previewView?.updateGhostImages([], opacity: 0)
     }
 

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -10,6 +10,10 @@ class CameraModel: ObservableObject {
     private let captureService = CaptureService()
     private let photoLibraryService = PhotoLibraryService()
     var previewView: PreviewView?
+
+    private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
+    private var previewAngleObservation: NSKeyValueObservation?
+    private var captureAngleObservation: NSKeyValueObservation?
     
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -58,6 +62,7 @@ class CameraModel: ObservableObject {
                 try await captureService.setUpSession()
                 await captureService.start()
                 isSessionRunning = true
+                await setUpRotationCoordinator()
             } catch {
                 alertMessage = "Failed to set up camera: \(error.localizedDescription)"
                 showAlert = true
@@ -67,7 +72,43 @@ class CameraModel: ObservableObject {
             showAlert = true
         }
     }
-    
+
+    /// Creates a RotationCoordinator for the active camera + preview layer and keeps the
+    /// preview and photo-output rotation angles up to date. Safe to call again after a
+    /// camera switch; it rebuilds the coordinator and observations.
+    func setUpRotationCoordinator() async {
+        guard let previewLayer = previewView?.previewLayer,
+              let device = await captureService.activeDevice else { return }
+
+        let coordinator = AVCaptureDevice.RotationCoordinator(device: device, previewLayer: previewLayer)
+        rotationCoordinator = coordinator
+
+        applyPreviewAngle(coordinator.videoRotationAngleForHorizonLevelPreview)
+        await applyCaptureAngle(coordinator.videoRotationAngleForHorizonLevelCapture)
+
+        previewAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelPreview,
+                                                      options: [.new]) { [weak self] _, change in
+            guard let angle = change.newValue else { return }
+            Task { @MainActor in self?.applyPreviewAngle(angle) }
+        }
+        captureAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelCapture,
+                                                      options: [.new]) { [weak self] _, change in
+            guard let angle = change.newValue else { return }
+            Task { @MainActor in await self?.applyCaptureAngle(angle) }
+        }
+    }
+
+    private func applyPreviewAngle(_ angle: CGFloat) {
+        guard let connection = previewView?.previewLayer.connection else { return }
+        if connection.isVideoRotationAngleSupported(angle) {
+            connection.videoRotationAngle = angle
+        }
+    }
+
+    private func applyCaptureAngle(_ angle: CGFloat) async {
+        await captureService.applyCaptureGeometry(rotationAngle: angle)
+    }
+
     func capturePhoto() {
         Task {
             do {
@@ -107,6 +148,7 @@ class CameraModel: ObservableObject {
                 try await captureService.switchCamera()
                 // Refresh overlay mirroring to match new camera connection
                 previewView?.refreshMirroring()
+                await setUpRotationCoordinator()
             } catch {
                 alertMessage = "Failed to switch camera: \(error.localizedDescription)"
                 showAlert = true

--- a/App/CameraPreview.swift
+++ b/App/CameraPreview.swift
@@ -214,10 +214,10 @@ class PreviewView: UIView, PreviewTarget {
     // Apply vertical flip always to match preview's coordinate system, and
     // horizontal flip when the preview connection is mirrored (front camera).
     private func applyCompositeTransform() {
-        let isMirrored = previewLayer.connection?.isVideoMirrored ?? false
-        let sx: CGFloat = isMirrored ? -1 : 1
-        let sy: CGFloat = -1
-        ghostCompositeLayer.setAffineTransform(CGAffineTransform(scaleX: sx, y: sy))
+        // Frames are captured upright and front-camera frames are mirrored to match the
+        // preview, so the ghost composite needs no extra flip. Kept as the single tuning
+        // point for overlay orientation.
+        ghostCompositeLayer.setAffineTransform(.identity)
     }
 
     // Public hook to refresh mirroring when camera changes

--- a/App/CameraPreview.swift
+++ b/App/CameraPreview.swift
@@ -189,14 +189,12 @@ class PreviewView: UIView, PreviewTarget {
         let renderer = UIGraphicsImageRenderer(size: canvasSize, format: format)
         let img = renderer.image { ctx in
             ctx.cgContext.clear(CGRect(origin: .zero, size: canvasSize))
-            // Draw each image aspect-fill into the canvas
+            // Draw each image aspect-fill into the canvas. Use UIImage.draw (not
+            // cgContext.draw(cgImage), which renders flipped in a UIKit top-left context)
+            // so the composite is upright and matches the save-time blend.
             for image in images {
-                guard let cg = image.cgImage else { continue }
-                ctx.cgContext.setBlendMode(.lighten)
-                // Use configurable per-exposure alpha so preview matches save-time blend
-                ctx.cgContext.setAlpha(ghostExposureAlpha)
-                let drawRect = aspectFillRect(forImageSize: CGSize(width: cg.width, height: cg.height), inCanvas: canvasSize)
-                ctx.cgContext.draw(cg, in: drawRect)
+                let drawRect = aspectFillRect(forImageSize: image.size, inCanvas: canvasSize)
+                image.draw(in: drawRect, blendMode: .lighten, alpha: ghostExposureAlpha)
             }
         }
         return img
@@ -274,6 +272,10 @@ struct CameraPreviewWithModel: UIViewRepresentable {
         cameraModel.previewView = preview  // Store reference
         // Initialize preview's per-exposure alpha to match model setting
         preview.ghostExposureAlpha = CGFloat(cameraModel.ghostExposureAlpha)
+        // Now that the preview layer exists, (re)build the RotationCoordinator. The call in
+        // initialize() can run before this view is created, so the coordinator would otherwise
+        // never apply its angles or front-camera mirroring.
+        Task { await cameraModel.setUpRotationCoordinator() }
         return preview
     }
     

--- a/App/CaptureService.swift
+++ b/App/CaptureService.swift
@@ -83,7 +83,28 @@ actor CaptureService {
     var currentCameraPosition: AVCaptureDevice.Position {
         return activeVideoInput?.device.position ?? .back
     }
-    
+
+    var activeDevice: AVCaptureDevice? {
+        activeVideoInput?.device
+    }
+
+    /// Applies the capture rotation angle and front/back mirroring to the photo-output
+    /// connection so captured pixel buffers come out upright (and mirrored for the front
+    /// camera, to match the mirrored preview).
+    func applyCaptureGeometry(rotationAngle: CGFloat) {
+        guard let connection = photoCapture.output.connection(with: .video) else { return }
+
+        if connection.isVideoRotationAngleSupported(rotationAngle) {
+            connection.videoRotationAngle = rotationAngle
+        }
+
+        let isFront = activeVideoInput?.device.position == .front
+        if connection.isVideoMirroringSupported {
+            connection.automaticallyAdjustsVideoMirroring = false
+            connection.isVideoMirrored = isFront
+        }
+    }
+
     func focusAt(point: CGPoint) async throws {
         guard let device = activeVideoInput?.device else { return }
         

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -11,18 +11,6 @@ struct ContentView: View {
                 }
                 .ignoresSafeArea()
 
-                // TEMP DEBUG HUD: confirms running build + shows orientation ground truth.
-                VStack {
-                    Text(cameraModel.debugInfo)
-                        .font(.system(size: 12, weight: .bold, design: .monospaced))
-                        .foregroundColor(.yellow)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color.black.opacity(0.6))
-                        .padding(.top, 56)
-                    Spacer()
-                }
-
                 VStack {
                     Spacer()
                     

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -10,7 +10,19 @@ struct ContentView: View {
                     cameraModel.focusAt(point: focusPoint)
                 }
                 .ignoresSafeArea()
-                
+
+                // TEMP DEBUG HUD: confirms running build + shows orientation ground truth.
+                VStack {
+                    Text(cameraModel.debugInfo)
+                        .font(.system(size: 12, weight: .bold, design: .monospaced))
+                        .foregroundColor(.yellow)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.black.opacity(0.6))
+                        .padding(.top, 56)
+                    Spacer()
+                }
+
                 VStack {
                     Spacer()
                     

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -33,6 +33,14 @@ struct ContentView: View {
                                     .font(.title3)
                                     .foregroundColor(.white)
                             }
+                            // Alignment toggle
+                            HStack(spacing: 8) {
+                                Image(systemName: "wand.and.stars")
+                                    .foregroundColor(cameraModel.isAlignmentEnabled ? .yellow : .gray)
+                                Toggle("Snap Align", isOn: $cameraModel.isAlignmentEnabled)
+                                    .labelsHidden()
+                                    .tint(.yellow)
+                            }
                         }
                         .padding(.bottom, 20)
                     }

--- a/App/ContentView.swift
+++ b/App/ContentView.swift
@@ -19,28 +19,18 @@ struct ContentView: View {
                     // The ghost composite uses lighten blend with a configurable per-exposure alpha
                     // to emulate save-time blending as closely as possible.
                     if !cameraModel.ghostPreviewImages.isEmpty {
-                        VStack(spacing: 10) {
-                            HStack(spacing: 15) {
-                                Image(systemName: "square.stack")
-                                    .font(.title3)
-                                    .foregroundColor(.white)
-                                
-                                Slider(value: $cameraModel.ghostOpacity, in: 0...1)
-                                    .accentColor(.white)
-                                    .frame(width: 260)
-                                
-                                Image(systemName: "camera")
-                                    .font(.title3)
-                                    .foregroundColor(.white)
-                            }
-                            // Alignment toggle
-                            HStack(spacing: 8) {
-                                Image(systemName: "wand.and.stars")
-                                    .foregroundColor(cameraModel.isAlignmentEnabled ? .yellow : .gray)
-                                Toggle("Snap Align", isOn: $cameraModel.isAlignmentEnabled)
-                                    .labelsHidden()
-                                    .tint(.yellow)
-                            }
+                        HStack(spacing: 15) {
+                            Image(systemName: "square.stack")
+                                .font(.title3)
+                                .foregroundColor(.white)
+                            
+                            Slider(value: $cameraModel.ghostOpacity, in: 0...1)
+                                .accentColor(.white)
+                                .frame(width: 260)
+                            
+                            Image(systemName: "camera")
+                                .font(.title3)
+                                .foregroundColor(.white)
                         }
                         .padding(.bottom, 20)
                     }
@@ -133,7 +123,17 @@ struct ContentView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.horizontal, 28)
-                    .padding(.bottom, 50)
+                    .padding(.bottom, 30)
+
+                    // Snap Align toggle placed below the shutter row
+                    HStack(spacing: 8) {
+                        Image(systemName: "wand.and.stars")
+                            .foregroundColor(cameraModel.isAlignmentEnabled ? .yellow : .gray)
+                        Toggle("Snap Align", isOn: $cameraModel.isAlignmentEnabled)
+                            .labelsHidden()
+                            .tint(.yellow)
+                    }
+                    .padding(.bottom, 20)
                 }
             } else {
                 VStack(spacing: 20) {

--- a/App/Docs/AlignmentDesign.md
+++ b/App/Docs/AlignmentDesign.md
@@ -1,0 +1,142 @@
+# Image Alignment & Stabilization Design (Vision + OpenCV)
+
+## Goals
+- Snap handheld captures so key structures align across exposures, creating a magical, stabilized double-exposure.
+- Preserve natural parallax for moving objects (cars, people), while aligning dominant scene geometry (buildings, faces).
+- Keep the live experience responsive (preview alignment feels instant, save-time alignment is robust).
+
+## User Experience
+- Live ghost preview: when a second shot is captured, the prior capture “snaps” into place so static structure aligns.
+- Save-time blend: use the best alignment at full resolution before compositing.
+- Defaults on; no extra UI. Optional advanced toggle for “Extra snap (beta)” to enable local refinement.
+
+## Pipeline Overview
+1) Optional semantic pre-align (Vision)
+   - Detect largest face in both images. If both exist:
+     - Compute similarity transform (scale + rotation + translation) using eye centers and inter-eye vector.
+     - Pre-warp the moving image with this transform.
+   - If no faces, skip.
+
+2) Global geometric alignment (OpenCV)
+   - Detect ORB features (1–2k keypoints) in reference and moving (downscaled to ~1–2MP for speed).
+   - Match with BFMatcher (Hamming). Ratio test (Lowe 0.75–0.8), and cross-check optional.
+   - Estimate homography via RANSAC: reprojThreshold ≈ 3 px (scaled), confidence ≈ 0.995, maxIters ≈ 2000.
+   - If homography fails (few inliers / singular), fallback to estimateAffinePartial2D (rotation+scale+translation).
+   - Track inlier count and inlier ratio for quality diagnostics.
+
+3) Warp to reference
+   - If H found: warpPerspective(moving, H) -> aligned.
+   - Else if affine A: warpAffine(moving, A) -> aligned.
+   - Re-apply transform at full resolution using scale factor from downscaled run.
+
+4) Optional local refinement (optical flow)
+   - Dense Farnebäck optical flow on a further downscaled pair; build small displacement field.
+   - Cap displacement magnitude to 2–3 px; upsample and apply to aligned image (remap) for subtle edge refinement.
+   - Time-bound to keep UI snappy (e.g., 20–40 ms budget); skip if over budget.
+
+5) Blend
+   - Return aligned `UIImage`; compose with Core Image blend (lighten, screen, etc.) as we already do.
+
+## Transform Selection Heuristics
+- Try homography first (handles perspective/planar scenes). If inliers < threshold (e.g., < 30 or inlier ratio < 0.2), fallback to affine.
+- If both images contain faces, run Vision pre-align, then features; still use homography if strong enough.
+- Local refinement only when user enables “Extra snap” and only if global alignment succeeds.
+
+## Downscale & Performance
+- Build a downscaled working copy at ~1–2MP (example: longest side ≈ 1400–1600 px). Record `scaleFactor` vs. full-res.
+- Run detection/matching/alignment on downscaled; apply resulting transform to full-res image for the final export.
+- Use persistent OpenCV objects where possible; reuse buffers to reduce allocations.
+- Place CPU-heavy steps on a background queue; do not block main thread.
+
+## Integration Points
+- Live Preview (ghost):
+  - Trigger alignment computation when the second (or subsequent) image is captured.
+  - Compute transform in background using downscaled frames and immediately re-warp the ghost overlay at preview size.
+  - Smooth the transform over a few preview frames (EMA) if we allow interactive opacity scrubbing.
+
+- Save-Time:
+  - Repeat alignment with the same seed but at full-res (or reuse previously computed H/A and scale it up precisely).
+  - Optionally enable local refinement flow before blending.
+
+## Public API (Swift)
+- `AlignmentEngine.align(moving: UIImage, reference: UIImage, options: AlignmentOptions) -> AlignmentResult`
+  - Options: `preferHomography: Bool`, `enableVisionPrealign: Bool`, `enableLocalRefine: Bool`, `downscaleTargetMP: Double`.
+  - Result:
+    - `alignedImage: UIImage` (same size as reference)
+    - `transformModel: TransformModel` (homography or affine + quality metrics)
+    - `metrics: AlignmentMetrics` (inliers, inlier ratio, runtime)
+
+- `AlignmentEngine.previewAlignForOverlay(moving: UIImage, referencePreviewSize: CGSize) -> UIImage` (fast path)
+  - Returns pre-warped moving image at preview size for ghost overlay.
+
+## Obj‑C++ Wrapper (OpenCV)
+- Objective-C++ class: `OCVAligner`
+  - `.alignHomography(cv::Mat moving, cv::Mat reference, params) -> cv::Mat H / bool success`
+  - `.alignAffinePartial(cv::Mat moving, cv::Mat reference, params) -> cv::Mat A / bool success`
+  - `.warpWithHomography(cv::Mat img, cv::Mat H, cv::Size size) -> cv::Mat`
+  - `.warpWithAffine(cv::Mat img, cv::Mat A, cv::Size size) -> cv::Mat`
+  - `.refineWithOpticalFlow(cv::Mat aligned, cv::Mat reference, capPx) -> cv::Mat`
+
+- Bridging header exposes a thin Swift wrapper `AlignmentEngine`.
+
+## Vision Pre‑Align (Similarity)
+- Detect faces with Vision: `VNDetectFaceLandmarksRequest`.
+- Find largest face in each image; compute eye centers and angle of inter-eye vector.
+- Compute similarity transform:
+  - Translate to face center, rotate to match eye-line angles, scale to match inter-eye distances.
+- Pre-warp moving image (Core Image or vImage) quickly; proceed to OpenCV features on the pre-warped pair.
+
+## Local Refinement (Optional)
+- Farnebäck params: pyramidScale ~0.5, levels 3–4, winsize 9–15, iterations 2–3, polyN 5, polySigma 1.2.
+- Generate displacement map; clamp magnitude to <= 2–3 px; remap.
+- Skip if runtime exceeds budget; fallback to global only.
+
+## Quality Metrics & Fallbacks
+- Homography considered valid if:
+  - Inliers ≥ 30 (after RANSAC) and inlier ratio ≥ 0.2–0.3.
+  - Determinant not near 0; no extreme skew.
+- If invalid → try affine; if still invalid → return unaligned moving (no worse than today).
+
+## Threading & Budgets
+- Live preview: target < 60–100 ms for alignment on downscaled images.
+- Save-time: tolerate 200–400 ms at full-res; do on background queue.
+- Use cancellation tokens so interactive actions can drop stale computations.
+
+## Storage & Memory
+- Reuse Mats, CIContexts; avoid retaining full-size intermediates longer than needed.
+- For preview, render directly at the preview size to minimize memory.
+
+## Error Handling
+- If OpenCV unavailable (build flag), disable alignment gracefully and use current behavior.
+- Log metrics for debugging (inliers, chosen model, runtime).
+
+## Phased Implementation Plan
+1) Scaffolding
+   - Add OpenCV dependency and bridging (Objective-C++ wrapper, module map, headers).
+   - Add `AlignmentEngine` Swift facade with no-op implementations.
+
+2) Global Alignment
+   - Implement ORB + BFMatcher + RANSAC homography with downscale.
+   - Add affine fallback; expose metrics.
+   - Integrate in preview overlay path and save-time path (behind a feature flag).
+
+3) Vision Pre‑Align (Similarity)
+   - Face detection + landmark extraction; compute similarity pre-warp.
+   - Feed pre-warped images into Step 2; measure improvement.
+
+4) Optional Local Refinement
+   - Farnebäck flow with magnitude clamp and timeout; integrate as a refinement pass.
+
+5) Smoothing & Heuristics
+   - EMA smoothing for preview transforms; auto-select model (H vs affine) based on inliers.
+
+6) Polish & Settings
+   - Feature flags in a hidden settings panel; diagnostics overlay (inlier count, model type).
+
+## Risks & Mitigations
+- Performance on older devices → aggressive downscale, early exits, timeout for flow stage.
+- Build complexity (OpenCV) → isolate in a module; compile-guard for simulator/device.
+- Robustness across scenes → rely on homography first, sensible thresholds, and fallbacks.
+
+---
+Last updated: Initial draft

--- a/App/Docs/AlignmentLog.md
+++ b/App/Docs/AlignmentLog.md
@@ -13,3 +13,12 @@ This running log tracks the alignment module work: what’s done and what’s ne
   3) Expose metrics; integrate preview alignment (fast path) behind a feature flag.
   4) Implement Vision pre-align and optional local refinement as follow-ups.
 
+### Update: Vision Alignment Wiring
+- Implemented Vision-based alignment in `App/Alignment/VisionAlignment.swift`:
+  - Uses `VNTranslationalImageRegistrationRequest` first; falls back to `VNHomographicImageRegistrationRequest`.
+  - Applies affine via Core Graphics; applies homography via `CIPerspectiveTransform` by warping corner points.
+  - Downscales to ~1–2MP for speed; scales transforms back to full resolution.
+- Integrated into `AlignmentEngine` (options.useAppleVision default true):
+  - `align(...)` now returns Vision-aligned output when available.
+  - `previewAlignForOverlay(...)` uses Vision as a best-effort (fallback to aspect-fill).
+- Next: Optionally integrate with live ghost overlay and save path behind a feature flag; add metrics logging.

--- a/App/Docs/AlignmentLog.md
+++ b/App/Docs/AlignmentLog.md
@@ -22,3 +22,8 @@ This running log tracks the alignment module work: what’s done and what’s ne
   - `align(...)` now returns Vision-aligned output when available.
   - `previewAlignForOverlay(...)` uses Vision as a best-effort (fallback to aspect-fill).
 - Next: Optionally integrate with live ghost overlay and save path behind a feature flag; add metrics logging.
+
+### Update: Save-Time Alignment Integration
+- Added a feature flag `CameraModel.isAlignmentEnabled` (default true).
+- In `savePhoto()`, when there are multiple images, each subsequent image is aligned to the first (reference) via `AlignmentEngine` using Vision (translation → homography) before blending.
+- Added simple console logs with model type and runtime per aligned image.

--- a/App/Docs/AlignmentLog.md
+++ b/App/Docs/AlignmentLog.md
@@ -1,0 +1,15 @@
+# Alignment Progress Log
+
+This running log tracks the alignment module work: what’s done and what’s next.
+
+## 2025-09-03
+- Added design document "AlignmentDesign.md" outlining the full pipeline (Vision pre-align, OpenCV homography/affine, optional optical flow), integration points, heuristics, and phased plan.
+- Scaffolded code:
+  - Swift API stub: `App/Alignment/AlignmentEngine.swift` with models, options, and no-op methods.
+  - ObjC++ placeholders: `App/Alignment/OCVAligner.h` and `.mm` (no OpenCV calls yet).
+- Next steps:
+  1) Add OpenCV to the project (SPM/CocoaPods/manual), create bridging, and wire `OCVAligner` into the target.
+  2) Implement ORB + BFMatcher + RANSAC homography and affine fallback at downscaled resolution.
+  3) Expose metrics; integrate preview alignment (fast path) behind a feature flag.
+  4) Implement Vision pre-align and optional local refinement as follow-ups.
+

--- a/App/Docs/AlignmentLog.md
+++ b/App/Docs/AlignmentLog.md
@@ -31,3 +31,11 @@ This running log tracks the alignment module work: what’s done and what’s ne
 ### Fix: Coordinate System for Vision Affine
 - Adjusted `VisionAligner.applyAffine` to flip the Core Graphics context to a bottom-left origin before applying Vision transforms.
 - This corrects horizontal translation direction and prevents exaggerated offsets in live preview.
+
+### Add: Vision Face Pre-Align (Similarity)
+- Implemented optional face-based similarity pre-warp in `VisionAligner.align` when `enableFacePrealign` is true.
+- Detects largest face in both images via Vision, computes eye centers and eye-line angle, and pre-warps the moving image to match scale/rotation/position before global registration.
+- Currently used in save-time pipeline (preview uses translation-only for responsiveness).
+
+### UI: Move Snap Align Toggle
+- Moved the “Snap Align” toggle below the shutter row; slider restored to its prior position above the bottom controls.

--- a/App/Docs/AlignmentLog.md
+++ b/App/Docs/AlignmentLog.md
@@ -27,3 +27,7 @@ This running log tracks the alignment module work: what’s done and what’s ne
 - Added a feature flag `CameraModel.isAlignmentEnabled` (default true).
 - In `savePhoto()`, when there are multiple images, each subsequent image is aligned to the first (reference) via `AlignmentEngine` using Vision (translation → homography) before blending.
 - Added simple console logs with model type and runtime per aligned image.
+
+### Fix: Coordinate System for Vision Affine
+- Adjusted `VisionAligner.applyAffine` to flip the Core Graphics context to a bottom-left origin before applying Vision transforms.
+- This corrects horizontal translation direction and prevents exaggerated offsets in live preview.

--- a/App/PhotoCapture.swift
+++ b/App/PhotoCapture.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import UIKit
 import CoreImage
+import ImageIO
 
 class PhotoCapture: NSObject {
     let output = AVCapturePhotoOutput()
@@ -72,7 +73,9 @@ private class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
         // Try to get image from pixel buffer first (for uncompressed format)
         if let pixelBuffer = photo.pixelBuffer {
             print("📸 DEBUG: Extracting image from pixel buffer (uncompressed)")
-            let image = UIImage.fromPixelBuffer(pixelBuffer)
+            // The pixel buffer is delivered in sensor-native orientation; the intended
+            // orientation lives in the photo's metadata. Apply it so the image is upright.
+            let image = UIImage.fromPixelBuffer(pixelBuffer, orientation: photo.cgImageOrientation)
             continuation.resume(returning: (image, photo))
             return
         }
@@ -100,17 +103,30 @@ private class PhotoCaptureDelegate: NSObject, AVCapturePhotoCaptureDelegate {
     }
 }
 
+extension AVCapturePhoto {
+    /// The intended display orientation of this photo, read from its metadata.
+    /// Falls back to `.up` if not present.
+    var cgImageOrientation: CGImagePropertyOrientation {
+        if let raw = metadata[kCGImagePropertyOrientation as String] as? UInt32,
+           let orientation = CGImagePropertyOrientation(rawValue: raw) {
+            return orientation
+        }
+        return .up
+    }
+}
+
 extension UIImage {
-    static func fromPixelBuffer(_ pixelBuffer: CVPixelBuffer) -> UIImage {
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
+    static func fromPixelBuffer(_ pixelBuffer: CVPixelBuffer,
+                                orientation: CGImagePropertyOrientation = .up) -> UIImage {
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer).oriented(orientation)
         let context = CIContext(options: nil)
-        
+
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
             print("📸 DEBUG: Failed to create CGImage from pixel buffer")
             return UIImage()
         }
-        
-        print("📸 DEBUG: Successfully created UIImage from pixel buffer, size: \(CGSize(width: cgImage.width, height: cgImage.height))")
+
+        print("📐 ORIENT: applied orientation rawValue=\(orientation.rawValue), result size=\(cgImage.width)x\(cgImage.height)")
         return UIImage(cgImage: cgImage)
     }
 }

--- a/App/PhotoCapture.swift
+++ b/App/PhotoCapture.swift
@@ -158,7 +158,6 @@ extension UIImage {
             tagged.draw(in: CGRect(origin: .zero, size: tagged.size))
         }
 
-        print("📐 ORIENT: exif=\(orientation.rawValue) ui=\(uiOrientation.rawValue) baked=\(Int(upright.size.width))x\(Int(upright.size.height))")
         return upright
     }
 }

--- a/App/PhotoCapture.swift
+++ b/App/PhotoCapture.swift
@@ -115,10 +115,27 @@ extension AVCapturePhoto {
     }
 }
 
+extension UIImage.Orientation {
+    /// Maps an EXIF/CGImage orientation to the semantically-equivalent UIImage orientation.
+    init(_ cg: CGImagePropertyOrientation) {
+        switch cg {
+        case .up: self = .up
+        case .upMirrored: self = .upMirrored
+        case .down: self = .down
+        case .downMirrored: self = .downMirrored
+        case .left: self = .left
+        case .leftMirrored: self = .leftMirrored
+        case .right: self = .right
+        case .rightMirrored: self = .rightMirrored
+        @unknown default: self = .up
+        }
+    }
+}
+
 extension UIImage {
     static func fromPixelBuffer(_ pixelBuffer: CVPixelBuffer,
                                 orientation: CGImagePropertyOrientation = .up) -> UIImage {
-        let ciImage = CIImage(cvPixelBuffer: pixelBuffer).oriented(orientation)
+        let ciImage = CIImage(cvPixelBuffer: pixelBuffer)
         let context = CIContext(options: nil)
 
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
@@ -126,7 +143,22 @@ extension UIImage {
             return UIImage()
         }
 
-        print("📐 ORIENT: applied orientation rawValue=\(orientation.rawValue), result size=\(cgImage.width)x\(cgImage.height)")
-        return UIImage(cgImage: cgImage)
+        // Tag the sensor-native (landscape) image with the intended orientation, then bake
+        // it into upright pixels via UIKit drawing (top-left coords — avoids the CIImage
+        // bottom-left .oriented() inversion). Downstream alignment uses raw .cgImage, so the
+        // pixels themselves must be upright, not just orientation-tagged.
+        let uiOrientation = UIImage.Orientation(orientation)
+        let tagged = UIImage(cgImage: cgImage, scale: 1, orientation: uiOrientation)
+
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: tagged.size, format: format)
+        let upright = renderer.image { _ in
+            tagged.draw(in: CGRect(origin: .zero, size: tagged.size))
+        }
+
+        print("📐 ORIENT: exif=\(orientation.rawValue) ui=\(uiOrientation.rawValue) baked=\(Int(upright.size.width))x\(Int(upright.size.height))")
+        return upright
     }
 }

--- a/Expexp.xcodeproj/project.pbxproj
+++ b/Expexp.xcodeproj/project.pbxproj
@@ -7,24 +7,35 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		043AF36FF0DEBF26851A0CAD /* AlignmentEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C84263122602465CE4302B /* AlignmentEngine.swift */; };
+		15DC512965243C11AE8FA3A1 /* OCVAligner.mm in Sources */ = {isa = PBXBuildFile; fileRef = 63F75E875C6B37440E550F13 /* OCVAligner.mm */; };
+		22DF97CBF42275A497D93BE4 /* CaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BAFF4F16BE251D02D56ACE /* CaptureService.swift */; };
+		4A590F31656D669E38695834 /* AlignmentLog.md in Resources */ = {isa = PBXBuildFile; fileRef = 78AFEF0582375267184506FB /* AlignmentLog.md */; };
+		54DE4DAB09F183B9C6339907 /* PhotoLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C57E4FF8C4AEA431FC2506 /* PhotoLibraryService.swift */; };
+		5B6F920C337AAE5E1772BBCE /* CameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4886568650B9CA47DDF2557 /* CameraModel.swift */; };
+		6A0A19F28E8E7D7092F08659 /* VisionAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E26EB170B5CEE1518D817BDC /* VisionAlignment.swift */; };
+		7DC4241358EF1505BCDD0BB8 /* AlignmentDesign.md in Resources */ = {isa = PBXBuildFile; fileRef = 459D5F7DB5E29632298EB2E6 /* AlignmentDesign.md */; };
 		8B36ECBE8F487D79C5BF6AAD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC1CEB119DB17FCFF76CBA5 /* ContentView.swift */; };
-		A1B2C3D4E5F6789012345678 /* CameraModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E2D3C4B5A6987654321098 /* CameraModel.swift */; };
-		B2C3D4E5F6A7890123456789 /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D3C4B5A6F8976543210987 /* CameraPreview.swift */; };
 		B3A794C7E99842CCF0752169 /* ExpexpApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEECD1650CE94D6154C6435C /* ExpexpApp.swift */; };
-		C3D4E5F6A7B8901234567890 /* CaptureService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C4B5A6F8E9876543210876 /* CaptureService.swift */; };
-		D4E5F6A7B8C9012345678901 /* PhotoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B5A6F8E9D7865432109765 /* PhotoCapture.swift */; };
-		E5F6A7B8C9D0123456789012 /* PhotoLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A6F8E9D7C6754321098654 /* PhotoLibraryService.swift */; };
+		E9E1D9E6232CD798B2DD5CFE /* CameraPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F00CB5A1F0A38703B90A7F /* CameraPreview.swift */; };
+		FEB64FAEB271E33507EA2D68 /* PhotoCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 473324B840A3C861AB6DEE7B /* PhotoCapture.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		0693997A4DB833E1D980874D /* Expexp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Expexp.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		B5A6F8E9D7C6754321098654 /* PhotoLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryService.swift; sourceTree = "<group>"; };
+		24F00CB5A1F0A38703B90A7F /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
+		459D5F7DB5E29632298EB2E6 /* AlignmentDesign.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AlignmentDesign.md; sourceTree = "<group>"; };
+		473324B840A3C861AB6DEE7B /* PhotoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCapture.swift; sourceTree = "<group>"; };
+		63F75E875C6B37440E550F13 /* OCVAligner.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OCVAligner.mm; sourceTree = "<group>"; };
+		78AFEF0582375267184506FB /* AlignmentLog.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AlignmentLog.md; sourceTree = "<group>"; };
+		B1BAFF4F16BE251D02D56ACE /* CaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureService.swift; sourceTree = "<group>"; };
+		B4886568650B9CA47DDF2557 /* CameraModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraModel.swift; sourceTree = "<group>"; };
 		BEC1CEB119DB17FCFF76CBA5 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
-		C4B5A6F8E9D7865432109765 /* PhotoCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCapture.swift; sourceTree = "<group>"; };
+		C2C84263122602465CE4302B /* AlignmentEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlignmentEngine.swift; sourceTree = "<group>"; };
 		CEECD1650CE94D6154C6435C /* ExpexpApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpexpApp.swift; sourceTree = "<group>"; };
-		D3C4B5A6F8E9876543210876 /* CaptureService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureService.swift; sourceTree = "<group>"; };
-		E2D3C4B5A6F8976543210987 /* CameraPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreview.swift; sourceTree = "<group>"; };
-		F1E2D3C4B5A6987654321098 /* CameraModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraModel.swift; sourceTree = "<group>"; };
+		D5C57E4FF8C4AEA431FC2506 /* PhotoLibraryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoLibraryService.swift; sourceTree = "<group>"; };
+		E26EB170B5CEE1518D817BDC /* VisionAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisionAlignment.swift; sourceTree = "<group>"; };
+		E8ACAD32A036F63B7EDDD20D /* OCVAligner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OCVAligner.h; sourceTree = "<group>"; };
 		FC7A21DA945374E0AB9E4119 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -32,16 +43,27 @@
 		2C50064C8FCA52915657C751 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				B4886568650B9CA47DDF2557 /* CameraModel.swift */,
+				24F00CB5A1F0A38703B90A7F /* CameraPreview.swift */,
+				B1BAFF4F16BE251D02D56ACE /* CaptureService.swift */,
 				BEC1CEB119DB17FCFF76CBA5 /* ContentView.swift */,
 				CEECD1650CE94D6154C6435C /* ExpexpApp.swift */,
-				F1E2D3C4B5A6987654321098 /* CameraModel.swift */,
-				E2D3C4B5A6F8976543210987 /* CameraPreview.swift */,
-				D3C4B5A6F8E9876543210876 /* CaptureService.swift */,
-				C4B5A6F8E9D7865432109765 /* PhotoCapture.swift */,
-				B5A6F8E9D7C6754321098654 /* PhotoLibraryService.swift */,
 				FC7A21DA945374E0AB9E4119 /* Info.plist */,
+				473324B840A3C861AB6DEE7B /* PhotoCapture.swift */,
+				D5C57E4FF8C4AEA431FC2506 /* PhotoLibraryService.swift */,
+				F1FEDC0B7D3A0FD36C2AF83C /* Alignment */,
+				3629D4C4D30EA3B1D94FF9B9 /* Docs */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		3629D4C4D30EA3B1D94FF9B9 /* Docs */ = {
+			isa = PBXGroup;
+			children = (
+				459D5F7DB5E29632298EB2E6 /* AlignmentDesign.md */,
+				78AFEF0582375267184506FB /* AlignmentLog.md */,
+			);
+			path = Docs;
 			sourceTree = "<group>";
 		};
 		5370381CE7E1888DC8DAE4EF = {
@@ -50,6 +72,17 @@
 				2C50064C8FCA52915657C751 /* App */,
 				FEBF26DFB9ED940D3A100646 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		F1FEDC0B7D3A0FD36C2AF83C /* Alignment */ = {
+			isa = PBXGroup;
+			children = (
+				C2C84263122602465CE4302B /* AlignmentEngine.swift */,
+				E8ACAD32A036F63B7EDDD20D /* OCVAligner.h */,
+				63F75E875C6B37440E550F13 /* OCVAligner.mm */,
+				E26EB170B5CEE1518D817BDC /* VisionAlignment.swift */,
+			);
+			path = Alignment;
 			sourceTree = "<group>";
 		};
 		FEBF26DFB9ED940D3A100646 /* Products */ = {
@@ -68,6 +101,7 @@
 			buildConfigurationList = ECEEBCE106EE40FFD0F7C05E /* Build configuration list for PBXNativeTarget "Expexp" */;
 			buildPhases = (
 				A8E2322039B0243A14B7D27D /* Sources */,
+				A187F29DE5C841DA90BB58D9 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -112,18 +146,33 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		A187F29DE5C841DA90BB58D9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DC4241358EF1505BCDD0BB8 /* AlignmentDesign.md in Resources */,
+				4A590F31656D669E38695834 /* AlignmentLog.md in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		A8E2322039B0243A14B7D27D /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				043AF36FF0DEBF26851A0CAD /* AlignmentEngine.swift in Sources */,
+				5B6F920C337AAE5E1772BBCE /* CameraModel.swift in Sources */,
+				E9E1D9E6232CD798B2DD5CFE /* CameraPreview.swift in Sources */,
+				22DF97CBF42275A497D93BE4 /* CaptureService.swift in Sources */,
 				8B36ECBE8F487D79C5BF6AAD /* ContentView.swift in Sources */,
 				B3A794C7E99842CCF0752169 /* ExpexpApp.swift in Sources */,
-				A1B2C3D4E5F6789012345678 /* CameraModel.swift in Sources */,
-				B2C3D4E5F6A7890123456789 /* CameraPreview.swift in Sources */,
-				C3D4E5F6A7B8901234567890 /* CaptureService.swift in Sources */,
-				D4E5F6A7B8C9012345678901 /* PhotoCapture.swift in Sources */,
-				E5F6A7B8C9D0123456789012 /* PhotoLibraryService.swift in Sources */,
+				15DC512965243C11AE8FA3A1 /* OCVAligner.mm in Sources */,
+				FEB64FAEB271E33507EA2D68 /* PhotoCapture.swift in Sources */,
+				54DE4DAB09F183B9C6339907 /* PhotoLibraryService.swift in Sources */,
+				6A0A19F28E8E7D7092F08659 /* VisionAlignment.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,13 +188,17 @@
 				DEVELOPMENT_TEAM = N7ZX6XG86A;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ventures.cull.expexp;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -160,13 +213,17 @@
 				DEVELOPMENT_TEAM = N7ZX6XG86A;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.photography";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = ventures.cull.expexp;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.9;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/docs/superpowers/plans/2026-06-27-orientation.md
+++ b/docs/superpowers/plans/2026-06-27-orientation.md
@@ -1,0 +1,429 @@
+# Orientation, Done Right — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every saved photo (single and multi-exposure, front and back camera) come out upright by handling rotation at capture time, and delete all the manual post-capture rotation hacks.
+
+**Architecture:** Add an `AVCaptureDevice.RotationCoordinator` (iOS 17) that feeds the correct rotation angle to both the preview layer connection and the photo-output connection, so captured pixel buffers are already upright. Front-camera output is mirrored to match the mirrored preview (WYSIWYG). With capture upright, all the scattered 90° rotation code is removed and the blend is rewritten to draw with `UIGraphicsImageRenderer` (which handles image orientation correctly), matching the existing live-preview compositor.
+
+**Tech Stack:** Swift, SwiftUI, AVFoundation (`AVCaptureDevice.RotationCoordinator`, `AVCaptureConnection.videoRotationAngle`), Core Graphics / UIKit image drawing.
+
+**Spec:** `docs/superpowers/specs/2026-06-27-orientation-design.md`
+
+**Why no automated tests:** This work depends on camera hardware and live AVFoundation connection geometry, which cannot be exercised in unit tests or the iOS Simulator. Each task is verified by a successful Simulator **compile** (`xcodebuild … build`) and a commit; behavioral correctness is verified by the **on-device manual checklist** in Task 6. Do not write placeholder/fake unit tests for this plan.
+
+**Implementation note (deviation from spec wording):** The spec said `CaptureService` would "own/refresh the RotationCoordinator." During planning it became clear the coordinator needs the `AVCaptureVideoPreviewLayer` (a `@MainActor` UIKit object owned by `PreviewView`), while `CaptureService` is an `actor` that owns the device and photo output. So the coordinator is owned by `CameraModel` (`@MainActor`), which already holds both the `previewView` and the `captureService`. This keeps orientation policy in one place and respects actor/UIKit isolation. Behavior matches the approved spec exactly.
+
+**Shared build command** (used as the compile check in every task):
+```bash
+xcodebuild -project Expexp.xcodeproj -scheme Expexp \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' build 2>&1 \
+  | grep -E "error:|BUILD SUCCEEDED|BUILD FAILED"
+```
+Expected at the end of each task: `** BUILD SUCCEEDED **` and no `error:` lines.
+
+**Branch:** Work happens on the existing `mini-1-orientation` branch.
+
+---
+
+## File structure
+
+- `Expexp.xcodeproj/project.pbxproj` — raise `IPHONEOS_DEPLOYMENT_TARGET` to 17.0.
+- `App/CaptureService.swift` — expose the active `AVCaptureDevice`; add a method to apply the
+  capture-connection rotation angle and front/back mirroring.
+- `App/CameraModel.swift` — own the `RotationCoordinator`; apply preview + capture angles; remove
+  all manual rotation methods/properties; simplify `capturePhoto`/`savePhoto`; rewrite
+  `blendImages` to use `UIGraphicsImageRenderer`.
+- `App/CameraPreview.swift` (`PreviewView`) — simplify the ghost-overlay composite transform now
+  that frames are upright.
+
+---
+
+## Task 1: Raise the deployment target to iOS 17
+
+**Files:**
+- Modify: `Expexp.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Replace the deployment target**
+
+In `Expexp.xcodeproj/project.pbxproj`, replace **all** occurrences of:
+```
+IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+```
+with:
+```
+IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+```
+(Use a replace-all; there is typically one entry per build configuration.)
+
+- [ ] **Step 2: Verify no 16.6 references remain**
+
+Run:
+```bash
+grep -n "IPHONEOS_DEPLOYMENT_TARGET" Expexp.xcodeproj/project.pbxproj
+```
+Expected: every line shows `= 17.0;`.
+
+- [ ] **Step 3: Compile check**
+
+Run the shared build command. Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Expexp.xcodeproj/project.pbxproj
+git commit -m "build: raise deployment target to iOS 17 for RotationCoordinator"
+```
+
+---
+
+## Task 2: Expose device + capture-geometry control from CaptureService
+
+This task is purely additive (new methods, not yet called), so it compiles with no behavior change.
+
+**Files:**
+- Modify: `App/CaptureService.swift`
+
+- [ ] **Step 1: Add an accessor for the active capture device**
+
+In `CaptureService` (after the existing `currentCameraPosition` computed property, around line 83), add:
+```swift
+    var activeDevice: AVCaptureDevice? {
+        activeVideoInput?.device
+    }
+```
+
+- [ ] **Step 2: Add a method to apply rotation angle + mirroring to the photo-output connection**
+
+In `CaptureService`, add this method (place it after `focusAt(point:)`):
+```swift
+    /// Applies the capture rotation angle and front/back mirroring to the photo-output
+    /// connection so captured pixel buffers come out upright (and mirrored for the front
+    /// camera, to match the mirrored preview).
+    func applyCaptureGeometry(rotationAngle: CGFloat) {
+        guard let connection = photoCapture.output.connection(with: .video) else { return }
+
+        if connection.isVideoRotationAngleSupported(rotationAngle) {
+            connection.videoRotationAngle = rotationAngle
+        }
+
+        let isFront = activeVideoInput?.device.position == .front
+        if connection.isVideoMirroringSupported {
+            connection.automaticallyAdjustsVideoMirroring = false
+            connection.isVideoMirrored = isFront
+        }
+    }
+```
+
+- [ ] **Step 3: Compile check**
+
+Run the shared build command. Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add App/CaptureService.swift
+git commit -m "feat: expose active device and capture-geometry control in CaptureService"
+```
+
+---
+
+## Task 3: Own the RotationCoordinator in CameraModel and apply angles
+
+Adds rotation wiring. The manual rotations are still present after this task, so the app is **not yet correct** (frames may be double-transformed) — that is fixed in Task 4. Do not device-test between Task 3 and Task 4. The compile check is the only gate here.
+
+**Files:**
+- Modify: `App/CameraModel.swift`
+
+- [ ] **Step 1: Add coordinator storage**
+
+In `CameraModel`, add these stored properties near the top of the class (just after `var previewView: PreviewView?` around line 12):
+```swift
+    private var rotationCoordinator: AVCaptureDevice.RotationCoordinator?
+    private var previewAngleObservation: NSKeyValueObservation?
+    private var captureAngleObservation: NSKeyValueObservation?
+```
+
+- [ ] **Step 2: Add the coordinator setup method**
+
+In `CameraModel`, add this method (place it just below `initialize()`):
+```swift
+    /// Creates a RotationCoordinator for the active camera + preview layer and keeps the
+    /// preview and photo-output rotation angles up to date. Safe to call again after a
+    /// camera switch; it rebuilds the coordinator and observations.
+    func setUpRotationCoordinator() async {
+        guard let previewLayer = previewView?.previewLayer,
+              let device = await captureService.activeDevice else { return }
+
+        let coordinator = AVCaptureDevice.RotationCoordinator(device: device, previewLayer: previewLayer)
+        rotationCoordinator = coordinator
+
+        applyPreviewAngle(coordinator.videoRotationAngleForHorizonLevelPreview)
+        await applyCaptureAngle(coordinator.videoRotationAngleForHorizonLevelCapture)
+
+        previewAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelPreview,
+                                                      options: [.new]) { [weak self] _, change in
+            guard let angle = change.newValue else { return }
+            Task { @MainActor in self?.applyPreviewAngle(angle) }
+        }
+        captureAngleObservation = coordinator.observe(\.videoRotationAngleForHorizonLevelCapture,
+                                                      options: [.new]) { [weak self] _, change in
+            guard let angle = change.newValue else { return }
+            Task { @MainActor in await self?.applyCaptureAngle(angle) }
+        }
+    }
+
+    private func applyPreviewAngle(_ angle: CGFloat) {
+        guard let connection = previewView?.previewLayer.connection else { return }
+        if connection.isVideoRotationAngleSupported(angle) {
+            connection.videoRotationAngle = angle
+        }
+    }
+
+    private func applyCaptureAngle(_ angle: CGFloat) async {
+        await captureService.applyCaptureGeometry(rotationAngle: angle)
+    }
+```
+
+- [ ] **Step 3: Call setup after the session starts**
+
+In `CameraModel.initialize()`, inside the `if isAuthorized { do { … } }` block, after `isSessionRunning = true` (around line 60), add:
+```swift
+                await setUpRotationCoordinator()
+```
+
+- [ ] **Step 4: Rebuild the coordinator after a camera switch**
+
+In `CameraModel.switchCamera()`, inside the `do` block after `previewView?.refreshMirroring()` (around line 109), add:
+```swift
+                await setUpRotationCoordinator()
+```
+
+- [ ] **Step 5: Compile check**
+
+Run the shared build command. Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add App/CameraModel.swift
+git commit -m "feat: drive preview/capture rotation via RotationCoordinator"
+```
+
+---
+
+## Task 4: Remove manual rotation and rewrite the blend
+
+This is the correctness swap. After this task the app captures and saves upright with no manual rotation. Steps must all land together (single commit) because intermediate states are inconsistent.
+
+**Files:**
+- Modify: `App/CameraModel.swift`
+
+- [ ] **Step 1: Stop rotating the ghost preview frame on capture**
+
+In `capturePhoto()`, replace these lines (around lines 88–90):
+```swift
+                // Rotate ghost to match camera preview orientation  
+                let rotatedGhost = rotateImageClockwise(image)
+                ghostPreviewImages.append(rotatedGhost)
+```
+with:
+```swift
+                // Frames are already upright (rotation handled at capture time).
+                ghostPreviewImages.append(image)
+```
+Also remove the now-stale debug line referencing `rotatedGhost` (around line 93):
+```swift
+                print("📷 DEBUG: Ghost image size: \(rotatedGhost.size), scale: \(rotatedGhost.scale) (rotated to match preview)")
+```
+
+- [ ] **Step 2: Remove first-capture orientation/camera bookkeeping**
+
+In `capturePhoto()`, delete this block (around lines 74–79):
+```swift
+                // Only capture orientation and camera position for the first image
+                if capturedRawImages.isEmpty {
+                    captureOrientation = UIDevice.current.orientation
+                    captureCamera = await captureService.currentCameraPosition
+                    print("📷 DEBUG: First capture - orientation: \(captureOrientation), camera: \(captureCamera)")
+                }
+```
+
+- [ ] **Step 3: Simplify the save path (no per-image rotation, no single-image rotation)**
+
+In `savePhoto()`, replace the whole processing+single-image block — from the comment `// Process raw images (apply rotation) at save time for speed` down through the end of the single-image `else` branch (the block that currently builds `processedImages` and the `if processedImages.count == 1 { … }` branch, around lines 136–159) — with:
+```swift
+                // Frames are captured upright; no rotation needed.
+                let processedImages = capturedRawImages
+
+                let finalImage: UIImage
+                if processedImages.count == 1 {
+                    finalImage = processedImages[0]
+                    print("🖼️ DEBUG: Single upright image saved as-is")
+                } else {
+```
+(Leave the existing multi-image alignment+blend body that follows — the `var imagesForBlend = processedImages` through `finalImage = blendImages(imagesForBlend)` — unchanged, and keep its closing brace.)
+
+- [ ] **Step 4: Rewrite `blendImages` to draw upright with UIGraphicsImageRenderer**
+
+Replace the entire `blendImages(_:)` method (around lines 313–370) with:
+```swift
+    private func blendImages(_ images: [UIImage]) -> UIImage {
+        guard let first = images.first else { return UIImage() }
+        guard images.count > 1 else { return first }
+
+        let canvasSize = first.size
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = first.scale
+        format.opaque = false
+        let renderer = UIGraphicsImageRenderer(size: canvasSize, format: format)
+        let drawRect = CGRect(origin: .zero, size: canvasSize)
+
+        return renderer.image { ctx in
+            ctx.cgContext.clear(drawRect)
+            // Lighten blend with per-exposure alpha, matching the live preview compositor.
+            // UIImage.draw handles image orientation correctly (no manual rotation needed).
+            for image in images {
+                image.draw(in: drawRect, blendMode: .lighten, alpha: CGFloat(ghostExposureAlpha))
+            }
+        }
+    }
+```
+
+- [ ] **Step 5: Delete the now-unused rotation helpers and properties**
+
+Delete these declarations entirely from `CameraModel`:
+- `rotateCGImageClockwise(_:)` (around lines 372–405)
+- `shouldRotateImage(_:for:cameraPosition:)` (around lines 407–426)
+- `rotateImage(_:for:cameraPosition:)` (around lines 428–486)
+- `rotateImageClockwise(_:)` (around lines 488–520)
+- the stored properties `captureOrientation` and `captureCamera` (around lines 46–47):
+```swift
+    private var captureOrientation: UIDeviceOrientation = .portrait
+    private var captureCamera: AVCaptureDevice.Position = .back
+```
+
+- [ ] **Step 6: Compile check (this also confirms nothing else referenced the deleted code)**
+
+Run the shared build command. Expected: `** BUILD SUCCEEDED **`. If the build reports an `error:` about an undefined symbol, it means a call site to one of the deleted methods was missed — find it with `grep -n "rotateImage\|rotateCGImageClockwise\|shouldRotateImage\|captureOrientation\|captureCamera" App/CameraModel.swift` and remove/fix that reference.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add App/CameraModel.swift
+git commit -m "refactor: remove manual rotation hacks; capture/blend now upright by construction"
+```
+
+---
+
+## Task 5: Simplify the ghost-overlay composite transform
+
+The overlay always vertical-flipped to compensate for the old flipped pixel space. With upright (and front-mirrored) frames, that compensation is no longer needed. Set the transform to identity; the on-device checklist (Task 6, step 5) confirms alignment and we tune here only if needed.
+
+**Files:**
+- Modify: `App/CameraPreview.swift`
+
+- [ ] **Step 1: Make the composite transform identity**
+
+In `PreviewView.applyCompositeTransform()` (around lines 216–221), replace the body:
+```swift
+    private func applyCompositeTransform() {
+        let isMirrored = previewLayer.connection?.isVideoMirrored ?? false
+        let sx: CGFloat = isMirrored ? -1 : 1
+        let sy: CGFloat = -1
+        ghostCompositeLayer.setAffineTransform(CGAffineTransform(scaleX: sx, y: sy))
+    }
+```
+with:
+```swift
+    private func applyCompositeTransform() {
+        // Frames are captured upright and front-camera frames are mirrored to match the
+        // preview, so the ghost composite needs no extra flip. Kept as the single tuning
+        // point for overlay orientation.
+        ghostCompositeLayer.setAffineTransform(.identity)
+    }
+```
+
+- [ ] **Step 2: Compile check**
+
+Run the shared build command. Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add App/CameraPreview.swift
+git commit -m "refactor: ghost overlay needs no flip now that frames are upright"
+```
+
+---
+
+## Task 6: On-device acceptance (manual)
+
+This is the real verification gate. Run on a physical iPhone (camera does not work in the Simulator). If any check fails, see "If a check fails" below.
+
+- [ ] **Step 1: Install on device**
+
+Connect the iPhone, select it as the run destination in Xcode, and Run (⌘R). (User performs this; the implementer should prompt for it and wait for results.)
+
+- [ ] **Step 2: Portrait, back camera — multi-exposure**
+
+Capture a 2–3 exposure stack of a scene with clear up/down (e.g., a window with sky on top), tap Save. Open Photos.
+Expected: composite is upright (sky on top), not rotated or flipped.
+
+- [ ] **Step 3: Portrait, front camera — multi-exposure**
+
+Switch to the front camera. Capture a stack that includes something asymmetric/readable (e.g., yourself holding text). Save.
+Expected: upright, and the composition matches what you framed in the mirrored preview (not surprisingly reversed).
+
+- [ ] **Step 4: Single exposure, back and front**
+
+Capture one shot on each camera and Save.
+Expected: both upright.
+
+- [ ] **Step 5: Live ghost overlay alignment**
+
+While shooting a stack, watch the translucent ghost of previous frames over the live feed.
+Expected: the ghost lines up with the live camera (same orientation/mirroring), no flipped or upside-down overlay.
+
+- [ ] **Step 6: Camera switch mid-session**
+
+Start a stack on the back camera, switch to front, take another, and Save.
+Expected: preview and captures stay correctly oriented across the switch.
+
+**If a check fails:**
+- Saved photo rotated 90°/180°: the capture angle isn't applying — verify `applyCaptureGeometry` runs (add a temporary `print` of the angle) and that `setUpRotationCoordinator()` is called after session start.
+- Front selfie reversed vs. what you framed: flip the mirroring intent — in `applyCaptureGeometry`, set `connection.isVideoMirrored = false` for front (saves un-mirrored like the stock Camera app). Rebuild and recheck step 3.
+- Ghost overlay flipped/upside-down only: adjust `applyCompositeTransform()` in `PreviewView` — reintroduce the minimal flip needed (`scaleX:1, y:-1` for vertical, or `scaleX:-1, y:1` for horizontal) until the overlay matches the live preview.
+
+- [ ] **Step 7: Final confirmation**
+
+Once all checks pass, the mini-project is complete. Leave the branch `mini-1-orientation` ready for review/merge (handled separately).
+
+---
+
+## Self-review
+
+**Spec coverage:**
+- Raise deployment target to 17 → Task 1. ✅
+- RotationCoordinator drives preview + capture angles → Tasks 2–3. ✅
+- Front-camera mirroring matches preview (WYSIWYG) → Task 2 (`applyCaptureGeometry` mirrors front). ✅
+- Remove manual rotation methods + bookkeeping → Task 4 steps 1,2,5. ✅
+- Remove single-image 90° rotation and per-image rotation pass → Task 4 step 3. ✅
+- Remove trailing rotate in blend → Task 4 step 4 (rewrite). ✅
+- Simplify overlay transform → Task 5. ✅
+- On-device testing checklist (all 6 spec checks) → Task 6 steps 2–6. ✅
+- Simulator build must still succeed → compile check in every task. ✅
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases". Each code step shows full code. The only
+"tune on device" item (overlay transform / mirroring) is an explicit, bounded fallback in Task 6,
+not a placeholder — the default implementation is fully specified.
+
+**Type/name consistency:** `setUpRotationCoordinator()`, `applyPreviewAngle(_:)`,
+`applyCaptureAngle(_:)`, `applyCaptureGeometry(rotationAngle:)`, and `activeDevice` are used
+consistently across Tasks 2 and 3. `blendImages(_:)` keeps its signature; callers in `savePhoto()`
+are unchanged. `ghostExposureAlpha` (existing property) reused in the blend rewrite.
+
+**Note on scope:** Rewriting `blendImages` to use `UIGraphicsImageRenderer` is included because the
+manual rotation being removed lived inside that method; removing it correctly requires fixing the
+draw context. The blend *mode* (lighten) and look are unchanged — improving the look is
+mini-project #2.

--- a/docs/superpowers/specs/2026-06-27-orientation-design.md
+++ b/docs/superpowers/specs/2026-06-27-orientation-design.md
@@ -1,0 +1,134 @@
+# Orientation, Done Right — Design Spec
+
+**Date:** 2026-06-27
+**Mini-project:** #1 of the expexp revival program
+**Status:** Approved for planning
+
+## Program context
+
+This is the first of five sequential mini-projects in the effort to upgrade the `expexp`
+double-exposure camera app. Each mini-project gets its own spec → plan → implement → on-device
+test cycle so the app stays working throughout. Agreed order:
+
+1. **Orientation, done right** ← this spec
+2. Color & blend looks
+3. Intuitive UI
+4. Alignment hardening (remove dead OpenCV, unify preview/save paths)
+5. Ship it (TestFlight → App Store)
+
+The app is a personal project; a secondary goal is to learn App Store shipping via phase 5.
+
+## Problem
+
+Photos are captured in the camera's native (rotated) pixel orientation, then "un-rotated"
+after the fact with hardcoded 90° rotations plus a device-orientation lookup table. This works
+in the common case (portrait, back camera) but produces sideways/flipped saves in other cases
+(observed: a composite saved rotated 90° to landscape). The orientation logic is spread across
+multiple methods and is the single most fragile part of the codebase.
+
+Current orientation-handling code (all to be removed or replaced):
+- `CameraModel.rotateImageClockwise(_:)` — applied to each ghost preview frame.
+- `CameraModel.rotateCGImageClockwise(_:)` — applied in `blendImages` and the single-photo save path.
+- `CameraModel.shouldRotateImage(_:for:cameraPosition:)` and `rotateImage(_:for:cameraPosition:)`
+  — device-orientation lookup table applied at save time.
+- `CameraModel.captureOrientation` / `captureCamera` — captured on the first frame to drive the above.
+- `PreviewView.applyCompositeTransform()` — always vertical-flips the ghost composite (and
+  horizontal-flips when mirrored) to compensate for the flipped pixel space.
+
+## Goals
+
+- Saved photos (single and multi-exposure) are always upright, for back and front cameras,
+  regardless of how the phone was held during a portrait-locked session.
+- Front-camera captures match what the user framed in the (mirrored) preview — WYSIWYG.
+- All exposures within one stack share a single, consistent orientation so they blend cleanly.
+- Delete the manual rotation code entirely; orientation becomes correct-by-construction.
+
+## Non-goals
+
+- Landscape capture / landscape UI. The app remains portrait-locked (`Info.plist` already
+  restricts to `UIInterfaceOrientationPortrait`). Upright-always is the contract.
+- Any change to capture, blend, save, alignment, or UI *behavior* beyond orientation.
+
+## Approach
+
+### 1. Raise the deployment target
+Set `IPHONEOS_DEPLOYMENT_TARGET = 17.0` (from 16.6). This unlocks
+`AVCaptureDevice.RotationCoordinator`. All known test devices run iOS 18+, so there is no
+practical device-coverage loss.
+
+### 2. Drive rotation at capture time with RotationCoordinator
+- Create an `AVCaptureDevice.RotationCoordinator` for the active camera + preview layer
+  (recreated when the camera switches in `CaptureService.switchCamera`).
+- Observe `videoRotationAngleForHorizonLevelPreview` → apply to the preview layer connection,
+  so the live preview is correctly oriented.
+- Observe `videoRotationAngleForHorizonLevelCapture` → apply to the photo output connection,
+  so captured pixel buffers come out upright. No post-capture rotation needed.
+- Because the UI is portrait-locked, in practice this resolves to the upright angle; using the
+  coordinator (rather than a hardcoded angle) keeps it correct and future-proof, and handles
+  the camera/preview wiring cleanly.
+
+### 3. Front-camera mirroring (WYSIWYG)
+- Keep the preview connection mirrored for the front camera (natural selfie feel; this is
+  effectively current behavior).
+- Mirror the front-camera captured output to match the preview, so framing the shot in the
+  mirrored preview produces the same composition in the saved photo. Back camera: no mirroring.
+- This keeps every exposure in a set consistent and makes "what you frame is what you get" true.
+
+### 4. Remove manual rotation and simplify the overlay
+- Delete the methods and stored properties listed under "Problem."
+- In `CameraModel.capturePhoto()`, append the captured image to the ghost preview buffer
+  without `rotateImageClockwise`.
+- In `CameraModel.savePhoto()`, remove the single-photo 90° rotation and the per-image
+  device-orientation rotation pass; blend/save the upright frames directly.
+- In `blendImages`, remove the trailing `rotateCGImageClockwise` step.
+- In `PreviewView`, simplify `applyCompositeTransform()`: the always-on vertical flip existed to
+  compensate for flipped pixels and is no longer needed once frames are upright. Retain only the
+  horizontal flip required to match a mirrored front-camera preview, if any is needed after the
+  capture path change. The exact residual transform is determined empirically during
+  implementation (see Testing); the end state is "ghost overlay lines up with live preview."
+
+## Components touched
+
+- `Expexp.xcodeproj/project.pbxproj` — deployment target 16.6 → 17.0.
+- `CaptureService.swift` — own/refresh the `RotationCoordinator`; apply rotation angles to the
+  preview and photo-output connections; set front-camera mirroring on capture.
+- `PhotoCapture.swift` — ensure capture settings/connection produce upright (and, for front,
+  mirrored) output; no post-rotation.
+- `CameraModel.swift` — delete all manual rotation methods and the orientation/camera
+  bookkeeping; simplify `capturePhoto`, `savePhoto`, `blendImages`.
+- `CameraPreview.swift` (`PreviewView`) — simplify the ghost composite transform.
+
+## Architecture notes
+
+Orientation becomes a property of the capture pipeline (one place: the `RotationCoordinator`
+wiring in `CaptureService`), rather than a cross-cutting concern patched at preview, blend, and
+save time. After this change, the rest of the app deals only in upright `UIImage`s, which also
+simplifies the later color/blend and alignment mini-projects.
+
+## Testing (on device — the camera does not work in the simulator)
+
+Manual acceptance checks, each performed on a physical iPhone:
+
+1. **Portrait, back camera:** capture a 2–3 exposure stack, Save → opens upright in Photos.
+2. **Portrait, front camera:** capture a stack → upright, and the composition matches what was
+   framed in the mirrored preview (text/asymmetric scene reads correctly, not reversed in a
+   surprising way).
+3. **Single exposure, back and front:** Save one shot → upright.
+4. **Regression on the previously-broken grab:** reproduce the kind of capture that produced the
+   sideways save → now upright.
+5. **Live ghost overlay:** while shooting a stack, the ghost of prior frames stays aligned with
+   the live camera feed (no flip/rotation mismatch).
+6. **Camera switch mid-session:** flip cameras and confirm preview + subsequent captures remain
+   correctly oriented.
+
+A build for the simulator (`xcodebuild … build`) must still succeed (compile-level check) before
+device testing.
+
+## Risks & mitigations
+
+- **Low risk overall.** Only affects orientation of new photos; no stored data is altered.
+- **Residual flip/rotation in preview or ghost overlay:** adjust the single composite transform
+  in `PreviewView` until the overlay matches the live preview (Testing step 5).
+- **Front-camera mirroring expectations:** if "match the preview" feels wrong in testing, the
+  alternative (save un-mirrored, like the stock Camera app default) is a one-line change; we pick
+  based on what looks right on device.


### PR DESCRIPTION
## Summary
First of five mini-projects reviving the expexp double-exposure app. Fixes the long-standing orientation fragility by handling rotation at **capture time** and deleting the scattered manual 90°-rotation hacks.

- Raise minimum iOS to **17** to use `AVCaptureDevice.RotationCoordinator`.
- Drive preview + photo-output rotation (and front-camera mirroring) from the coordinator; trigger its setup once the preview view exists (avoids a startup race).
- **Root-cause fix for rotated saves:** `photo.pixelBuffer` is delivered in sensor-native orientation, so `PhotoCapture` now bakes the camera's orientation metadata into upright pixels via `UIImage.draw` (not `CIImage.oriented`, which inverts on a bottom-left origin).
- Delete all manual rotation code (`rotateImage*`, `shouldRotateImage`, device-orientation bookkeeping); rewrite the save blend and the live ghost overlay to draw with `UIImage.draw` (`cgContext.draw(cgImage)` renders flipped in UIKit contexts). Net: ~150 lines of fragile code removed.
- Front-camera saves now match the mirrored preview (WYSIWYG).

Spec: `docs/superpowers/specs/2026-06-27-orientation-design.md`
Plan: `docs/superpowers/plans/2026-06-27-orientation.md`

## Test Plan
Camera code can't be exercised in the simulator, so verification is a clean compile + on-device acceptance (both done):
- [x] Simulator build succeeds (`** BUILD SUCCEEDED **`)
- [x] Portrait back camera — multi-exposure saves upright
- [x] Portrait front camera — saves upright, matches mirrored framing
- [x] Single exposure (both cameras) — upright
- [x] Live ghost overlay aligns with the live preview (no flip)
- [x] Previously-broken sideways/upside-down cases now upright

## Known follow-up (not in scope here)
Front-camera multi-exposures shift layers horizontally — preview vs. save-time alignment use different code paths and the Vision face pre-align is confused by mirroring. Tracked for mini-project #4 (alignment hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)