### PR TITLE
Mini-project #4 (Phase B): Face-anchored selfie swirl

### DIFF
--- a/App/Alignment/AlignmentService.swift
+++ b/App/Alignment/AlignmentService.swift
@@ -68,6 +68,9 @@ enum AlignmentService {
 
     /// Acceptable face-scale ratio; outside this we assume a bad detection and fall back.
     static let faceScaleRange: ClosedRange<CGFloat> = 0.3...3.0
+    /// Max plausible face rotation between handheld frames. Beyond this = bad detection (e.g. a
+    /// mislocated eye producing a ~90° swing), so we fall back rather than spin the frame.
+    static let maxFaceRotation: CGFloat = .pi / 6  // 30°
 
     private static func faceAlignment(moving: UIImage, reference: UIImage) -> FrameAlignment {
         guard let movCG = moving.cgImage, let refCG = reference.cgImage,
@@ -90,7 +93,10 @@ enum AlignmentService {
         let rLen = max(hypot(rVec.dx, rVec.dy), 1e-6)
         let scale = rLen / mLen
         guard faceScaleRange.contains(scale) else { return .unlocked }
-        let rotation = atan2(rVec.dy, rVec.dx) - atan2(mVec.dy, mVec.dx)
+        // Normalize the rotation to [-π, π] and reject implausible swings (bad eye detection).
+        let rawRotation = atan2(rVec.dy, rVec.dx) - atan2(mVec.dy, mVec.dx)
+        let rotation = atan2(sin(rawRotation), cos(rawRotation))
+        guard abs(rotation) <= maxFaceRotation else { return .unlocked }
 
         // Anchor = moving eye midpoint (normalized to moving image). Shift maps moving mid → ref
         // mid, normalized to the moving image dims (the frame the compositor draws).

--- a/App/Alignment/AlignmentService.swift
+++ b/App/Alignment/AlignmentService.swift
@@ -36,7 +36,7 @@ enum AlignmentService {
     static func alignment(moving: UIImage, reference: UIImage, anchor: AlignmentAnchor) -> FrameAlignment {
         switch anchor {
         case .scene: return sceneAlignment(moving: moving, reference: reference)
-        case .face:  return .unlocked   // implemented in Phase B (Task B1)
+        case .face:  return faceAlignment(moving: moving, reference: reference)
         }
     }
 
@@ -62,6 +62,68 @@ enum AlignmentService {
         if abs(dx) > maxShiftFraction || abs(dy) > maxShiftFraction { return .unlocked }
         return FrameAlignment(dx: dx, dy: dy, rotation: 0, scale: 1,
                               anchor: CGPoint(x: 0.5, y: 0.5), locked: true)
+    }
+
+    // MARK: - Face (similarity: translate + rotate + uniform scale, pinned to the face)
+
+    /// Acceptable face-scale ratio; outside this we assume a bad detection and fall back.
+    static let faceScaleRange: ClosedRange<CGFloat> = 0.3...3.0
+
+    private static func faceAlignment(moving: UIImage, reference: UIImage) -> FrameAlignment {
+        guard let movCG = moving.cgImage, let refCG = reference.cgImage,
+              let mEyes = eyeCenters(in: movCG), let rEyes = eyeCenters(in: refCG) else {
+            return .unlocked
+        }
+        // Pixel-space geometry (true angle/scale); image dims for normalization.
+        let mw = CGFloat(movCG.width), mh = CGFloat(movCG.height)
+        let rw = CGFloat(refCG.width), rh = CGFloat(refCG.height)
+        let mL = CGPoint(x: mEyes.left.x * mw, y: mEyes.left.y * mh)
+        let mR = CGPoint(x: mEyes.right.x * mw, y: mEyes.right.y * mh)
+        let rL = CGPoint(x: rEyes.left.x * rw, y: rEyes.left.y * rh)
+        let rR = CGPoint(x: rEyes.right.x * rw, y: rEyes.right.y * rh)
+
+        let mMidPx = CGPoint(x: (mL.x + mR.x) / 2, y: (mL.y + mR.y) / 2)
+        let rMidPx = CGPoint(x: (rL.x + rR.x) / 2, y: (rL.y + rR.y) / 2)
+        let mVec = CGVector(dx: mR.x - mL.x, dy: mR.y - mL.y)
+        let rVec = CGVector(dx: rR.x - rL.x, dy: rR.y - rL.y)
+        let mLen = max(hypot(mVec.dx, mVec.dy), 1e-6)
+        let rLen = max(hypot(rVec.dx, rVec.dy), 1e-6)
+        let scale = rLen / mLen
+        guard faceScaleRange.contains(scale) else { return .unlocked }
+        let rotation = atan2(rVec.dy, rVec.dx) - atan2(mVec.dy, mVec.dx)
+
+        // Anchor = moving eye midpoint (normalized to moving image). Shift maps moving mid → ref
+        // mid, normalized to the moving image dims (the frame the compositor draws).
+        let anchor = CGPoint(x: mMidPx.x / mw, y: mMidPx.y / mh)
+        let dx = (rMidPx.x / rw) - (mMidPx.x / mw)
+        let dy = (rMidPx.y / rh) - (mMidPx.y / mh)
+        return FrameAlignment(dx: dx, dy: dy, rotation: rotation, scale: scale, anchor: anchor, locked: true)
+    }
+
+    private struct EyeCenters { let left: CGPoint; let right: CGPoint }  // normalized, top-left origin
+
+    /// Largest face's eye centers, normalized (0...1) in top-left coordinates.
+    private static func eyeCenters(in cgImage: CGImage) -> EyeCenters? {
+        let request = VNDetectFaceLandmarksRequest()
+        let handler = VNImageRequestHandler(cgImage: cgImage)
+        do { try handler.perform([request]) } catch { return nil }
+        guard let faces = request.results, !faces.isEmpty else { return nil }
+        guard let face = faces.max(by: {
+            $0.boundingBox.width * $0.boundingBox.height < $1.boundingBox.width * $1.boundingBox.height
+        }) else { return nil }
+        guard let lm = face.landmarks,
+              let left = lm.leftEye?.normalizedPoints, !left.isEmpty,
+              let right = lm.rightEye?.normalizedPoints, !right.isEmpty else { return nil }
+        let bbox = face.boundingBox
+        func center(_ pts: [CGPoint]) -> CGPoint {
+            let sum = pts.reduce(CGPoint.zero) { CGPoint(x: $0.x + $1.x, y: $0.y + $1.y) }
+            let n = CGFloat(pts.count)
+            // Landmark points are normalized within the bbox, bottom-left origin.
+            let xBL = bbox.origin.x + (sum.x / n) * bbox.size.width
+            let yBL = bbox.origin.y + (sum.y / n) * bbox.size.height
+            return CGPoint(x: xBL, y: 1 - yBL)  // → top-left origin
+        }
+        return EyeCenters(left: center(left), right: center(right))
     }
 
     // MARK: - Helpers

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -32,8 +32,6 @@ class CameraModel: ObservableObject {
     }
     /// Briefly true when a just-captured frame could not be aligned (Magic on).
     @Published var showAlignmentWarning: Bool = false
-    /// TEMP DEBUG: front-camera orientation/face-rotation diagnostics.
-    @Published var debugInfo: String = "F1"
 
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -162,12 +160,10 @@ class CameraModel: ObservableObject {
                 // Compute this frame's alignment relative to the first (reference) frame.
                 if capturedRawImages.count == 1 {
                     transforms = [.identity]
-                    debugInfo = "F1 #1 \(Int(image.size.width))x\(Int(image.size.height)) prev\(Int(lastPreviewAngle)) \(currentAnchor == .face ? "face" : "scene")"
                 } else if isAlignmentEnabled, let reference = capturedRawImages.first {
                     let a = AlignmentService.alignment(moving: image, reference: reference, anchor: currentAnchor)
                     transforms.append(a)
                     if !a.locked { flashAlignmentWarning() }
-                    debugInfo = "F1 #\(capturedRawImages.count) \(Int(image.size.width))x\(Int(image.size.height)) rot\(Int(a.rotation * 180 / .pi)) sc\(String(format: "%.2f", a.scale)) lk\(a.locked ? 1 : 0)"
                 } else {
                     transforms.append(.identity)
                 }

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -24,8 +24,12 @@ class CameraModel: ObservableObject {
 
     /// Alignment of each captured frame relative to frame 0 (parallel to capturedRawImages).
     private var transforms: [FrameAlignment] = []
-    /// Anchor for alignment. Phase A always uses .scene; Phase B selects by camera.
-    private var currentAnchor: AlignmentAnchor { .scene }
+    /// Active camera position, used to pick the alignment anchor.
+    private var captureCameraPosition: AVCaptureDevice.Position = .back
+    /// Anchor: front camera freezes the face (selfie swirl); back camera freezes the scene.
+    private var currentAnchor: AlignmentAnchor {
+        captureCameraPosition == .front ? .face : .scene
+    }
     /// Briefly true when a just-captured frame could not be aligned (Magic on).
     @Published var showAlignmentWarning: Bool = false
 
@@ -78,6 +82,7 @@ class CameraModel: ObservableObject {
                 await captureService.start()
                 isSessionRunning = true
                 await setUpRotationCoordinator()
+                captureCameraPosition = await captureService.currentCameraPosition
             } catch {
                 alertMessage = "Failed to set up camera: \(error.localizedDescription)"
                 showAlert = true
@@ -181,6 +186,9 @@ class CameraModel: ObservableObject {
                 // Refresh overlay mirroring to match new camera connection
                 previewView?.refreshMirroring()
                 await setUpRotationCoordinator()
+                captureCameraPosition = await captureService.currentCameraPosition
+                recomputeTransforms()
+                updateGhostPreviewOverlay()
             } catch {
                 alertMessage = "Failed to switch camera: \(error.localizedDescription)"
                 showAlert = true

--- a/App/CameraModel.swift
+++ b/App/CameraModel.swift
@@ -32,6 +32,8 @@ class CameraModel: ObservableObject {
     }
     /// Briefly true when a just-captured frame could not be aligned (Magic on).
     @Published var showAlignmentWarning: Bool = false
+    /// TEMP DEBUG: front-camera orientation/face-rotation diagnostics.
+    @Published var debugInfo: String = "F1"
 
     @Published var isAuthorized = false
     @Published var isSessionRunning = false
@@ -160,10 +162,12 @@ class CameraModel: ObservableObject {
                 // Compute this frame's alignment relative to the first (reference) frame.
                 if capturedRawImages.count == 1 {
                     transforms = [.identity]
+                    debugInfo = "F1 #1 \(Int(image.size.width))x\(Int(image.size.height)) prev\(Int(lastPreviewAngle)) \(currentAnchor == .face ? "face" : "scene")"
                 } else if isAlignmentEnabled, let reference = capturedRawImages.first {
                     let a = AlignmentService.alignment(moving: image, reference: reference, anchor: currentAnchor)
                     transforms.append(a)
                     if !a.locked { flashAlignmentWarning() }
+                    debugInfo = "F1 #\(capturedRawImages.count) \(Int(image.size.width))x\(Int(image.size.height)) rot\(Int(a.rotation * 180 / .pi)) sc\(String(format: "%.2f", a.scale)) lk\(a.locked ? 1 : 0)"
                 } else {
                     transforms.append(.identity)
                 }
@@ -283,9 +287,12 @@ class CameraModel: ObservableObject {
             previewView?.setOverlayImage(nil, opacity: 0)
             return
         }
-        // Degrees the overlay must rotate to match the live preview (which leans on the device).
-        // Portrait baseline is 90; landscape gives ±90, upside-down 180.
-        let delta = lastPreviewAngle - 90
+        // Degrees the overlay must rotate to match the live preview. The portrait baseline is
+        // camera-specific: the back lens reports 90 in portrait, the front lens reports 0 (their
+        // sensors are mounted 90° apart). Subtracting the baseline yields 0 in portrait and ±90
+        // in landscape for both lenses.
+        let portraitBaseline: CGFloat = (captureCameraPosition == .front) ? 0 : 90
+        let delta = lastPreviewAngle - portraitBaseline
         let quarterTurned = (Int(delta.rounded()) % 180 + 180) % 180 == 90
         // Build the composite in the device's display orientation, then rotate it for the
         // portrait-locked overlay layer so it lines up with the rotated live feed.


### PR DESCRIPTION
## Summary
Adds the front-camera "selfie swirl" to the rebuilt alignment: the user's face stays pinned and clear while the background ghosts/swirls around it. Builds on Phase A's single-path (WYSIWYG) alignment.

- **Face/similarity alignment** in `AlignmentService`: detect the largest face (Vision landmarks), compute a translate+rotate+uniform-scale transform from the eye centers that pins the moving face onto the reference face.
- **Anchor by camera:** front camera → face-freeze, back camera → scene-freeze (Phase A). Recomputes on camera switch.
- **Guards:** falls back to "as shot" if no face is found, if the scale is implausible (outside 0.3–3.0), or if the rotation swing exceeds 30° (kills the occasional bad-detection 90° spin).
- **On-device fix found during testing:** the front lens reports its portrait preview angle as 0 (the back lens reports 90) because the sensors are mounted 90° apart — so the ghost-overlay rotation baseline is now camera-aware, fixing a 90° CCW ghost spin on the front camera.

Spec: `docs/superpowers/specs/2026-06-28-alignment-design.md`
Plan: `docs/superpowers/plans/2026-06-28-alignment.md` (Phase B)

## Test Plan (on device)
- [x] Simulator build succeeds
- [x] Front camera: face stays pinned, background ghosts/swirls; preview == save
- [x] Front + back, portrait + landscape: ghost overlay upright and matched (no spin)
- [x] No-face / bad-detection frames fall back gracefully (no wild rotation)
- [x] Back-camera scene alignment unchanged from Phase A

🤖 Generated with [Claude Code](https://claude.com/claude-code)